### PR TITLE
Add native math support

### DIFF
--- a/common/defines.h
+++ b/common/defines.h
@@ -133,4 +133,18 @@ enum {C=0,N=1,O=2,H=3,XX=4,P=5,S=6};  // see "bond_index" in the "AD4.1_bound.da
 // Enables switching between native and non-native math in device code
 //#define SYCL_NATIVE_MATH
 
+#ifdef SYCL_NATIVE_MATH
+	#define SYCL_SQRT(x) sycl::native::sqrt(x)
+	#define SYCL_SIN(x) sycl::native::sin(x)
+	#define SYCL_COS(x) sycl::native::cos(x)
+	#define SYCL_DIVIDE(x,y) sycl::native::divide(x,y)
+	#define SYCL_RECIP(x) sycl::native::recip(x)
+#else
+	#define SYCL_SQRT(x) sycl::sqrt(x)
+	#define SYCL_SIN(x) sycl::sin(x)
+	#define SYCL_COS(x) sycl::cos(x)
+	#define SYCL_DIVIDE(x,y) (x/y)
+	#define SYCL_RECIP(x) (1.0f/x)
+#endif
+
 #endif /* DEFINES_H_ */

--- a/common/defines.h
+++ b/common/defines.h
@@ -130,4 +130,7 @@ enum {C=0,N=1,O=2,H=3,XX=4,P=5,S=6};  // see "bond_index" in the "AD4.1_bound.da
 // Output for the -modpair keyword
 // #define MODPAIR_INFO
 
+// Enables switching between native and non-native math in device code
+//#define SYCL_NATIVE_MATH
+
 #endif /* DEFINES_H_ */

--- a/dpcpp/calcMergeEneGra.dp.cpp
+++ b/dpcpp/calcMergeEneGra.dp.cpp
@@ -27,7 +27,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
 
-#define SYCL_NATIVE_MATH
+//#define SYCL_NATIVE_MATH
 
 #ifdef DOCK_TRACE
 #ifdef __SYCL_DEVICE_ONLY__

--- a/dpcpp/calcMergeEneGra.dp.cpp
+++ b/dpcpp/calcMergeEneGra.dp.cpp
@@ -262,7 +262,7 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
 	float weights[8];
 	float cube[8];
 	#ifdef SYCL_NATIVE_MATH
-	float inv_grid_spacing=1.0f * sycl::native::recip(cData.dockpars.grid_spacing);
+	float inv_grid_spacing=sycl::native::recip(cData.dockpars.grid_spacing);
 	#else
 	float inv_grid_spacing=1.0f/cData.dockpars.grid_spacing;
 	#endif
@@ -679,13 +679,13 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
 			#endif
 #ifndef DIEL_FIT_ABC
 													#ifdef SYCL_NATIVE_MATH
-													-sycl::native::divide(es_energy * 2.21718f, (dist2*dist_shift))
+													-sycl::native::divide(es_energy * 2.21718f, dist2 * dist_shift)
 													#else
 													-es_energy * 2.21718f / (dist2*dist_shift)
 													#endif
 #else
 													#ifdef SYCL_NATIVE_MATH
-													-es_energy * (sycl::native::divide(2.808f, dist2*dist_shift) + sycl::native::divide(0.288f, disth4*disth_shift))
+													-es_energy * (sycl::native::divide(2.808f, dist2 * dist_shift) + sycl::native::divide(0.288f, disth4 * disth_shift))
 													#else
 			                                       	-es_energy * ((2.808f / (dist2*dist_shift)) + (0.288f / (disth4*disth_shift)))
 													#endif

--- a/dpcpp/calcMergeEneGra.dp.cpp
+++ b/dpcpp/calcMergeEneGra.dp.cpp
@@ -128,21 +128,12 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
 	float genrotangle = genotype[5] * DEG_TO_RAD;
 
         sycl::float4 genrot_unitvec;
-		#ifdef SYCL_NATIVE_MATH
-		float sin_angle = sycl::native::sin(theta);
-		float s2 = sycl::native::sin(genrotangle * 0.5f);
-		genrot_unitvec.x() = s2 * sin_angle * sycl::native::cos(phi);
-		genrot_unitvec.y() = s2 * sin_angle * sycl::native::sin(phi);
-		genrot_unitvec.z() = s2 * sycl::native::cos(theta);
-		genrot_unitvec.w() = sycl::native::cos(genrotangle * 0.5f);
-		#else
-        float sin_angle = sycl::sin(theta);
-        float s2 = sycl::sin(genrotangle * 0.5f);
-        genrot_unitvec.x() = s2 * sin_angle * sycl::cos(phi);
-        genrot_unitvec.y() = s2 * sin_angle * sycl::sin(phi);
-        genrot_unitvec.z() = s2 * sycl::cos(theta);
-        genrot_unitvec.w() = sycl::cos(genrotangle * 0.5f);
-		#endif
+		float sin_angle = SYCL_SIN(theta);
+		float s2 = SYCL_SIN(genrotangle * 0.5f);
+		genrot_unitvec.x() = s2 * sin_angle * SYCL_COS(phi);
+		genrot_unitvec.y() = s2 * sin_angle * SYCL_SIN(phi);
+		genrot_unitvec.z() = s2 * SYCL_COS(theta);
+		genrot_unitvec.w() = SYCL_COS(genrotangle * 0.5f);
         float is_theta_gt_pi = 1.0f-2.0f*(float)(sin_angle < 0.0f);
 
 	uint32_t  g1 = cData.dockpars.gridsize_x;
@@ -198,11 +189,7 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
 				uint32_t rotbond_id = (rotation_list_element & RLIST_RBONDID_MASK) >> RLIST_RBONDID_SHIFT;
 
 				float rotation_angle = genotype[6+rotbond_id]*DEG_TO_RAD*0.5f;
-				#ifdef SYCL_NATIVE_MATH
-								float s = sycl::native::sin(rotation_angle);
-				#else
-                                float s = sycl::sin(rotation_angle);
-				#endif
+                                float s = SYCL_SIN(rotation_angle);
                                 rotation_unitvec.x() =
                                     s * cData.pKerconst_conform
                                             ->rotbonds_unit_vectors_const
@@ -215,11 +202,8 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
                                     s * cData.pKerconst_conform
                                             ->rotbonds_unit_vectors_const
                                                 [3 * rotbond_id + 2];
-				#ifdef SYCL_NATIVE_MATH
-								rotation_unitvec.w() = sycl::native::cos(rotation_angle);
-				#else
-                                rotation_unitvec.w() = sycl::cos(rotation_angle);
-				#endif
+                                rotation_unitvec.w() = SYCL_COS(rotation_angle);
+
                                 rotation_movingvec.x() =
                                     cData.pKerconst_conform
                                         ->rotbonds_moving_vectors_const
@@ -260,11 +244,8 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
 	// ================================================
 	float weights[8];
 	float cube[8];
-	#ifdef SYCL_NATIVE_MATH
-	float inv_grid_spacing=sycl::native::recip(cData.dockpars.grid_spacing);
-	#else
-	float inv_grid_spacing=1.0f/cData.dockpars.grid_spacing;
-	#endif
+	float inv_grid_spacing = SYCL_RECIP(cData.dockpars.grid_spacing);
+
         for (uint32_t atom_id = item_ct1.get_local_id(2);
              atom_id < cData.dockpars.num_of_atoms;
              atom_id += item_ct1.get_local_range().get(2))
@@ -524,11 +505,7 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
                 float subz = calc_coords[atom1_id].z() - calc_coords[atom2_id].z();
 
                 // Calculating atomic_distance
-		#ifdef SYCL_NATIVE_MATH
-				float dist = sycl::native::sqrt(subx * subx + suby * suby + subz * subz);
-		#else
-                float dist = sycl::sqrt(subx * subx + suby * suby + subz * subz);
-		#endif
+				float dist = SYCL_SQRT(subx * subx + suby * suby + subz * subz);
                 float atomic_distance = dist * cData.dockpars.grid_spacing;
 
 		// Getting type IDs
@@ -577,14 +554,10 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
                         float rm = sycl::pown(smoothed_distance, -m);
                         energy += (cData.pKerconst_intra->VWpars_AC_const[idx]
 			           -rmn*cData.pKerconst_intra->VWpars_BD_const[idx])*rm;
-			#ifdef SYCL_NATIVE_MATH
-			priv_gradient_per_intracontributor += sycl::native::divide((n*cData.pKerconst_intra->VWpars_BD_const[idx]*rmn
+
+			priv_gradient_per_intracontributor += SYCL_DIVIDE((n*cData.pKerconst_intra->VWpars_BD_const[idx]*rmn
 			                                      -m*cData.pKerconst_intra->VWpars_AC_const[idx])*rm, smoothed_distance);
-			#else
-			priv_gradient_per_intracontributor += (n*cData.pKerconst_intra->VWpars_BD_const[idx]*rmn
-			                                      -m*cData.pKerconst_intra->VWpars_AC_const[idx])*rm
-			                                      /smoothed_distance;
-			#endif
+
 			#if defined (DEBUG_ENERGY_KERNEL)
 			intraE += (cData.pKerconst_intra->VWpars_AC_const[idx]
 			           -rmn*cData.pKerconst_intra->VWpars_BD_const[idx])*rm
@@ -614,48 +587,27 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
                               cData.dockpars.qasp * sycl::fabs(q2)) *
                                  cData.pKerconst_intra
                                      ->dspars_V_const[atom1_typeid]) *
-				#ifdef SYCL_NATIVE_MATH
-							sycl::native::divide
+							SYCL_DIVIDE
                             (
 								cData.dockpars.coeff_desolv * (12.96f - 0.1063f * dist2 * (1.0f - 0.001947f * dist2)),
 								(12.96f + dist2 * (0.4137f + dist2 * (0.00357f + 0.000112f * dist2)))
 							);
-				#else
-                            (cData.dockpars.coeff_desolv *
-                             (12.96f -
-                              0.1063f * dist2 * (1.0f - 0.001947f * dist2)) /
-                             (12.96f +
-                              dist2 * (0.4137f + dist2 * (0.00357f +
-                                                          0.000112f * dist2))));
-				#endif
 
                         // Calculating electrostatic term
 #ifndef DIEL_FIT_ABC
 			float dist_shift=atomic_distance+1.26366f;
 			dist2=dist_shift*dist_shift;
-			#ifdef SYCL_NATIVE_MATH
-			float diel = sycl::native::divide(1.10859f, dist2) + 0.010358f;
-			#else
-			float diel = 1.10859f / dist2 + 0.010358f;
-			#endif
+			float diel = SYCL_DIVIDE(1.10859f, dist2) + 0.010358f;
 #else
 			float dist_shift=atomic_distance+1.588f;
 			dist2=dist_shift*dist_shift;
 			float disth_shift=atomic_distance+0.794f;
 			float disth4=disth_shift*disth_shift;
 			disth4*=disth4;
-			#ifdef SYCL_NATIVE_MATH
-			float diel = sycl::native::divide(1.404f, dist2) + sycl::native::divide(0.072f, disth4) + 0.00831f;
-			#else
-			float diel = 1.404f / dist2 + 0.072f / disth4 + 0.00831f;
-			#endif
+			float diel = SYCL_DIVIDE(1.404f, dist2) + SYCL_DIVIDE(0.072f, disth4) + 0.00831f;
 #endif
 
-			#ifdef SYCL_NATIVE_MATH
-			float es_energy = sycl::native::divide(cData.dockpars.coeff_elec * q1 * q2, atomic_distance);
-			#else
-			float es_energy = cData.dockpars.coeff_elec * q1 * q2 / atomic_distance;
-			#endif
+			float es_energy = SYCL_DIVIDE(cData.dockpars.coeff_elec * q1 * q2, atomic_distance);
 			energy += diel * es_energy + desolv_energy;
 
 			#if defined (DEBUG_ENERGY_KERNEL)
@@ -671,23 +623,13 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
 
 //			priv_gradient_per_intracontributor +=  -dockpars_coeff_elec * q1 * q2 * native_divide (upper, lower) -
 //			                                       0.0771605f * atomic_distance * desolv_energy;
-			#ifdef SYCL_NATIVE_MATH
-			priv_gradient_per_intracontributor +=  sycl::native::divide(-es_energy, atomic_distance) * diel
-			#else
-			priv_gradient_per_intracontributor +=  -(es_energy / atomic_distance) * diel
-			#endif
+
+			priv_gradient_per_intracontributor +=  SYCL_DIVIDE(-es_energy, atomic_distance) * diel
+
 #ifndef DIEL_FIT_ABC
-													#ifdef SYCL_NATIVE_MATH
-													-sycl::native::divide(es_energy * 2.21718f, dist2 * dist_shift)
-													#else
-													-es_energy * 2.21718f / (dist2*dist_shift)
-													#endif
+													-SYCL_DIVIDE(es_energy * 2.21718f, dist2 * dist_shift)
 #else
-													#ifdef SYCL_NATIVE_MATH
-													-es_energy * (sycl::native::divide(2.808f, dist2 * dist_shift) + sycl::native::divide(0.288f, disth4 * disth_shift))
-													#else
-			                                       	-es_energy * ((2.808f / (dist2*dist_shift)) + (0.288f / (disth4*disth_shift)))
-													#endif
+													-es_energy * (SYCL_DIVIDE(2.808f, dist2 * dist_shift) + SYCL_DIVIDE(0.288f, disth4 * disth_shift))
 #endif
 			                                       -0.0771605f * atomic_distance * desolv_energy; // 1/3.6^2 = 1/12.96 = 0.0771605
 		} // if cuttoff2 - internuclear-distance at 20.48A
@@ -696,11 +638,8 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
 		// into the contribution of each atom of the pair.
 		// Distances in Angstroms of vector that goes from
 		// "atom1_id"-to-"atom2_id", therefore - subx, - suby, and - subz are used
-		#ifdef SYCL_NATIVE_MATH
-		float grad_div_dist = sycl::native::divide(-priv_gradient_per_intracontributor, dist);
-		#else
-		float grad_div_dist = -priv_gradient_per_intracontributor / dist;
-		#endif
+		float grad_div_dist = SYCL_DIVIDE(-priv_gradient_per_intracontributor, dist);
+
 #ifdef FLOAT_GRADIENTS
 		float priv_intra_gradient_x = subx * grad_div_dist;
 		float priv_intra_gradient_y = suby * grad_div_dist;
@@ -930,18 +869,9 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
 		// Finding the quaternion that performs
 		// the infinitesimal rotation around torque axis
                 sycl::float4 quat_torque;
-				#ifdef SYCL_NATIVE_MATH
-				quat_torque.x() = sycl::native::divide(torque_rot.x() * SIN_HALF_INFINITESIMAL_RADIAN, torque_length);
-                quat_torque.y() = sycl::native::divide(torque_rot.y() * SIN_HALF_INFINITESIMAL_RADIAN, torque_length);
-                quat_torque.z() = sycl::native::divide(torque_rot.z() * SIN_HALF_INFINITESIMAL_RADIAN, torque_length);
-				#else
-                quat_torque.x() = torque_rot.x() *
-                                  SIN_HALF_INFINITESIMAL_RADIAN / torque_length;
-                quat_torque.y() = torque_rot.y() *
-                                  SIN_HALF_INFINITESIMAL_RADIAN / torque_length;
-                quat_torque.z() = torque_rot.z() *
-                                  SIN_HALF_INFINITESIMAL_RADIAN / torque_length;
-				#endif
+				quat_torque.x() = SYCL_DIVIDE(torque_rot.x() * SIN_HALF_INFINITESIMAL_RADIAN, torque_length);
+                quat_torque.y() = SYCL_DIVIDE(torque_rot.y() * SIN_HALF_INFINITESIMAL_RADIAN, torque_length);
+                quat_torque.z() = SYCL_DIVIDE(torque_rot.z() * SIN_HALF_INFINITESIMAL_RADIAN, torque_length);
                 quat_torque.w() = COS_HALF_INFINITESIMAL_RADIAN;
 
 #if defined (PRINT_GRAD_ROTATION_GENES)
@@ -980,23 +910,9 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
 		// In our terms means quaternion_to_oclacube(target_q{w|x|y|z}, theta_larger_than_pi)
                 target_rotangle = 2.0f * fast_acos(target_q.w()); // = 2.0f * ang;
 
-				#ifdef SYCL_NATIVE_MATH
-				float sin_ang = sycl::native::sqrt(1.0f - target_q.w() * target_q.w()); // = native_sin(ang);
-				#else
-                float sin_ang = sycl::sqrt(
-                    1.0f - target_q.w() * target_q.w()); // = native_sin(ang);
-				#endif
+				float sin_ang = SYCL_SQRT(1.0f - target_q.w() * target_q.w()); // = native_sin(ang);
 
-				#ifdef SYCL_NATIVE_MATH
-                target_theta =
-                    PI_TIMES_2 +
-                    is_theta_gt_pi * fast_acos(sycl::native::divide(target_q.z(), sin_ang));
-				#else
-                target_theta =
-                    PI_TIMES_2 +
-                    is_theta_gt_pi * fast_acos(target_q.z() / sin_ang);
-				#endif
-
+                target_theta = PI_TIMES_2 + is_theta_gt_pi * fast_acos(SYCL_DIVIDE(target_q.z(), sin_ang));
 
                 target_phi =
                     fmod_pi2((sycl::atan2(is_theta_gt_pi * target_q.y(),
@@ -1117,25 +1033,13 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
 
 		// Setting gradient rotation-related genotypes in cube
 		// Multiplicating by DEG_TO_RAD is to make it uniform to DEG (see torsion gradients)
-		#ifdef SYCL_NATIVE_MATH
                 gradient_genotype[3] = sycl::rint(sycl::fmin(
                     (float)MAXTERM,
-                    sycl::fmax(-MAXTERM, TERMSCALE * sycl::native::divide(grad_phi, dependence_on_theta * dependence_on_rotangle) * DEG_TO_RAD)));
-		#else
-                gradient_genotype[3] = sycl::rint(sycl::fmin(
-                    (float)MAXTERM,
-                    sycl::fmax(-MAXTERM, TERMSCALE * (grad_phi / (dependence_on_theta * dependence_on_rotangle)) * DEG_TO_RAD)));
-		#endif
+                    sycl::fmax(-MAXTERM, TERMSCALE * SYCL_DIVIDE(grad_phi, dependence_on_theta * dependence_on_rotangle) * DEG_TO_RAD)));
 
-		#ifdef SYCL_NATIVE_MATH
                 gradient_genotype[4] = sycl::rint(sycl::fmin(
                     (float)MAXTERM,
-                    sycl::fmax(-MAXTERM, TERMSCALE * sycl::native::divide(grad_theta, dependence_on_rotangle) * DEG_TO_RAD)));
-		#else
-                gradient_genotype[4] = sycl::rint(sycl::fmin(
-                    (float)MAXTERM,
-                    sycl::fmax(-MAXTERM, TERMSCALE * (grad_theta / dependence_on_rotangle) * DEG_TO_RAD)));
-		#endif
+                    sycl::fmax(-MAXTERM, TERMSCALE * SYCL_DIVIDE(grad_theta, dependence_on_rotangle) * DEG_TO_RAD)));
 
                 gradient_genotype[5] = sycl::rint(
                     sycl::fmin((float)MAXTERM,
@@ -1187,7 +1091,7 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
                 functionality. Check the potential precision and/or performance
                 issues for the generated code.
                 */
-                float l = sycl::native::recip(sycl::fast_length(
+                float l = SYCL_RECIP(sycl::fast_length(
                     sycl::float3(rotation_unitvec.x(), rotation_unitvec.y(),
                                  rotation_unitvec.z())));
                 rotation_unitvec.x() *= l;

--- a/dpcpp/calcMergeEneGra.dp.cpp
+++ b/dpcpp/calcMergeEneGra.dp.cpp
@@ -1,5 +1,6 @@
 #include <CL/sycl.hpp>
 #include <dpct/dpct.hpp>
+#include "defines.h"
 /*
 
 AutoDock-GPU, an OpenCL implementation of AutoDock 4.2 running a Lamarckian
@@ -26,8 +27,6 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
-
-//#define SYCL_NATIVE_MATH
 
 #ifdef DOCK_TRACE
 #ifdef __SYCL_DEVICE_ONLY__

--- a/dpcpp/calcenergy.dp.cpp
+++ b/dpcpp/calcenergy.dp.cpp
@@ -27,7 +27,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
 
-#define SYCL_NATIVE_MATH
+//#define SYCL_NATIVE_MATH
 
 //#define DEBUG_ENERGY_KERNEL
 

--- a/dpcpp/calcenergy.dp.cpp
+++ b/dpcpp/calcenergy.dp.cpp
@@ -527,8 +527,8 @@ SYCL_EXTERNAL void gpu_calc_energy(float *pGenotype, float &energy, int &run_id,
 			float dist_shift=atomic_distance+1.26366f;
 			dist2=dist_shift*dist_shift;
                         #ifdef SYCL_NATIVE_MATH
-                        float diel = (1.10859f * sycl::native::recip(dist2)) + 0.010358f;
-                        float es_energy = cData.dockpars.coeff_elec * q1 * q2 * sycl::native::recip(atomic_distance);
+                        float diel = sycl::native::divide(1.10859f, dist2) + 0.010358f;
+                        float es_energy = sycl::native::divide(cData.dockpars.coeff_elec * q1 * q2, atomic_distance);
                         #else
 			float diel = (1.10859f / dist2)+0.010358f;
 			float es_energy = cData.dockpars.coeff_elec * q1 * q2 / atomic_distance;

--- a/dpcpp/calcenergy.dp.cpp
+++ b/dpcpp/calcenergy.dp.cpp
@@ -1,5 +1,6 @@
 #include <CL/sycl.hpp>
 #include <dpct/dpct.hpp>
+#include "defines.h"
 /*
 
 AutoDock-GPU, an OpenCL implementation of AutoDock 4.2 running a Lamarckian
@@ -26,8 +27,6 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
-
-//#define SYCL_NATIVE_MATH
 
 //#define DEBUG_ENERGY_KERNEL
 

--- a/dpcpp/calcenergy.dp.cpp
+++ b/dpcpp/calcenergy.dp.cpp
@@ -27,6 +27,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
 
+#define SYCL_NATIVE_MATH
+
 //#define DEBUG_ENERGY_KERNEL
 
 #define invpi2 1.0f/(PI_TIMES_2)
@@ -66,8 +68,13 @@ SYCL_EXTERNAL __dpct_inline__ float fast_acos(float cosine)
              fast_acos_c) *
                 x +
             fast_acos_d +
-            fast_acos_e * sycl::sqrt(2.0f - sycl::sqrt(2.0f + 2.0f * x)) -
-            fast_acos_f * sycl::sqrt(2.0f - 2.0f * x);
+        #ifdef SYCL_NATIVE_MATH
+                fast_acos_e * sycl::native::sqrt(2.0f - sycl::native::sqrt(2.0f + 2.0f * x)) -
+                fast_acos_f * sycl::native::sqrt(2.0f - 2.0f * x);
+        #else
+                fast_acos_e * sycl::sqrt(2.0f - sycl::sqrt(2.0f + 2.0f * x)) -
+                fast_acos_f * sycl::sqrt(2.0f - 2.0f * x);
+        #endif
         return sycl::copysign(ac, cosine) + (cosine < 0.0f) * PI_FLOAT;
 }
 
@@ -163,12 +170,21 @@ SYCL_EXTERNAL void gpu_calc_energy(float *pGenotype, float &energy, int &run_id,
 	float genrotangle = pGenotype[5] * DEG_TO_RAD;
 
         sycl::float4 genrot_unitvec;
+        #ifdef SYCL_NATIVE_MATH
+        float sin_angle = sycl::native::sin(theta);
+        float s2 = sycl::native::sin(genrotangle * 0.5f);
+        genrot_unitvec.x() = s2 * sin_angle * sycl::native::cos(phi);
+        genrot_unitvec.y() = s2 * sin_angle * sycl::native::sin(phi);
+        genrot_unitvec.z() = s2 * sycl::native::cos(theta);
+        genrot_unitvec.w() = sycl::native::cos(genrotangle * 0.5f);
+        #else
         float sin_angle = sycl::sin(theta);
         float s2 = sycl::sin(genrotangle * 0.5f);
         genrot_unitvec.x() = s2 * sin_angle * sycl::cos(phi);
         genrot_unitvec.y() = s2 * sin_angle * sycl::sin(phi);
         genrot_unitvec.z() = s2 * sycl::cos(theta);
         genrot_unitvec.w() = sycl::cos(genrotangle * 0.5f);
+        #endif
 
         uint g1 = cData.dockpars.gridsize_x;
 	uint g2 = cData.dockpars.gridsize_x_times_y;
@@ -223,7 +239,11 @@ SYCL_EXTERNAL void gpu_calc_energy(float *pGenotype, float &energy, int &run_id,
 				uint rotbond_id = (rotation_list_element & RLIST_RBONDID_MASK) >> RLIST_RBONDID_SHIFT;
 
 				float rotation_angle = pGenotype[6+rotbond_id]*DEG_TO_RAD*0.5f;
+                                #ifdef SYCL_NATIVE_MATH
+                                float s = sycl::native::sin(rotation_angle);
+                                #else
                                 float s = sycl::sin(rotation_angle);
+                                #endif                  
                                 rotation_unitvec.x() =
                                     s * cData.pKerconst_conform
                                             ->rotbonds_unit_vectors_const
@@ -236,7 +256,11 @@ SYCL_EXTERNAL void gpu_calc_energy(float *pGenotype, float &energy, int &run_id,
                                     s * cData.pKerconst_conform
                                             ->rotbonds_unit_vectors_const
                                                 [3 * rotbond_id + 2];
+                                #ifdef SYCL_NATIVE_MATH
+                                rotation_unitvec.w() = sycl::native::cos(rotation_angle);
+                                #else
                                 rotation_unitvec.w() = sycl::cos(rotation_angle);
+                                #endif
                                 rotation_movingvec.x() =
                                     cData.pKerconst_conform
                                         ->rotbonds_moving_vectors_const
@@ -402,7 +426,11 @@ SYCL_EXTERNAL void gpu_calc_energy(float *pGenotype, float &energy, int &run_id,
                 float subz = calc_coords[atom1_id].z() - calc_coords[atom2_id].z();
 
                 // Calculating atomic_distance
+                #ifdef SYCL_NATIVE_MATH
+                float dist = sycl::native::sqrt(subx * subx + suby * suby + subz * subz);
+                #else
                 float dist = sycl::sqrt(subx * subx + suby * suby + subz * subz);
+                #endif
                 float atomic_distance = dist * cData.dockpars.grid_spacing;
 		if(atomic_distance<0.01f) atomic_distance=0.01f;
 
@@ -482,17 +510,29 @@ SYCL_EXTERNAL void gpu_calc_energy(float *pGenotype, float &energy, int &run_id,
                               cData.dockpars.qasp * sycl::fabs(q2)) *
                                  cData.pKerconst_intra
                                      ->dspars_V_const[atom1_typeid]) *
+                        #ifdef SYCL_NATIVE_MATH
+                                sycl::native::divide(
+                                        cData.dockpars.coeff_desolv * (12.96f - 0.1063f * dist2 * (1.0f - 0.001947f * dist2)),
+                                        (12.96f + dist2 * (0.4137f + dist2 * (0.00357f + 0.000112f * dist2)))
+                                );
+                        #else
                             (cData.dockpars.coeff_desolv *
                              (12.96f -
                               0.1063f * dist2 * (1.0f - 0.001947f * dist2)) /
                              (12.96f +
                               dist2 * (0.4137f + dist2 * (0.00357f +
                                                           0.000112f * dist2))));
+                        #endif
                         // Calculating electrostatic term
 			float dist_shift=atomic_distance+1.26366f;
 			dist2=dist_shift*dist_shift;
+                        #ifdef SYCL_NATIVE_MATH
+                        float diel = (1.10859f * sycl::native::recip(dist2)) + 0.010358f;
+                        float es_energy = cData.dockpars.coeff_elec * q1 * q2 * sycl::native::recip(atomic_distance);
+                        #else
 			float diel = (1.10859f / dist2)+0.010358f;
 			float es_energy = cData.dockpars.coeff_elec * q1 * q2 / atomic_distance;
+                        #endif
 			energy += diel * es_energy + desolv_energy;
 
 			#if defined (DEBUG_ENERGY_KERNEL)


### PR DESCRIPTION
This PR adds native math support by adding alternative code that can be enabled by uncommenting`#define SYCL_NATIVE_MATH` in _calcenergy.dp.cpp_ and _calcMergeEneGra.dp.cpp_.

Evaluations on DevCloud Gen9 GPU using `make DEVICE=XeGPU TESTLS=sw test` and `make DEVICE=XeGPU TESTLS=ad test` result in the following docking times (in seconds):

|                 |  Solis-Wets    |  ADADELTA   |
| -----------| ---------------|---------------|
| Non-native (original)    |  63.5    | 45.3    |
| Native      |  58.8    | 35.9    |
