### PR TITLE
Add switches between local and global memory for barriers + missing native

### DIFF
--- a/common/defines.h
+++ b/common/defines.h
@@ -131,7 +131,7 @@ enum {C=0,N=1,O=2,H=3,XX=4,P=5,S=6};  // see "bond_index" in the "AD4.1_bound.da
 // #define MODPAIR_INFO
 
 // Enables switching between native and non-native math in device code
-//#define SYCL_NATIVE_MATH
+#define SYCL_NATIVE_MATH
 
 #ifdef SYCL_NATIVE_MATH
 	#define SYCL_SQRT(x) sycl::native::sqrt(x)
@@ -145,6 +145,15 @@ enum {C=0,N=1,O=2,H=3,XX=4,P=5,S=6};  // see "bond_index" in the "AD4.1_bound.da
 	#define SYCL_COS(x) sycl::cos(x)
 	#define SYCL_DIVIDE(x,y) (x/y)
 	#define SYCL_RECIP(x) (1.0f/x)
+#endif
+
+// Enables switching between local and global memory for barriers in device code
+#define SYCL_LOCAL_BARRIER
+
+#ifdef SYCL_LOCAL_BARRIER
+	#define SYCL_MEMORY_SPACE sycl::access::fence_space::local_space
+#else
+	#define SYCL_MEMORY_SPACE
 #endif
 
 #endif /* DEFINES_H_ */

--- a/common/defines.h
+++ b/common/defines.h
@@ -135,12 +135,14 @@ enum {C=0,N=1,O=2,H=3,XX=4,P=5,S=6};  // see "bond_index" in the "AD4.1_bound.da
 
 #ifdef SYCL_NATIVE_MATH
 	#define SYCL_SQRT(x) sycl::native::sqrt(x)
+	#define SYCL_RSQRT(x) sycl::native::rsqrt(x)
 	#define SYCL_SIN(x) sycl::native::sin(x)
 	#define SYCL_COS(x) sycl::native::cos(x)
 	#define SYCL_DIVIDE(x,y) sycl::native::divide(x,y)
 	#define SYCL_RECIP(x) sycl::native::recip(x)
 #else
 	#define SYCL_SQRT(x) sycl::sqrt(x)
+	#define SYCL_RSQRT(x) (1.0f/SYCL_SQRT(x))
 	#define SYCL_SIN(x) sycl::sin(x)
 	#define SYCL_COS(x) sycl::cos(x)
 	#define SYCL_DIVIDE(x,y) (x/y)

--- a/dpcpp/calcMergeEneGra.dp.cpp
+++ b/dpcpp/calcMergeEneGra.dp.cpp
@@ -1,6 +1,6 @@
 #include <CL/sycl.hpp>
 #include <dpct/dpct.hpp>
-#include "defines.h"
+
 /*
 
 AutoDock-GPU, an OpenCL implementation of AutoDock 4.2 running a Lamarckian
@@ -145,7 +145,7 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
         DPC++ Compatibility Tool.
         */
         __threadfence();
-        item_ct1.barrier(sycl::access::fence_space::local_space);
+        item_ct1.barrier(SYCL_MEMORY_SPACE);
 
         // ================================================
 	// CALCULATING ATOMIC POSITIONS AFTER ROTATIONS
@@ -236,7 +236,7 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
                 Intel(R) DPC++ Compatibility Tool.
                 */
                 __threadfence();
-                item_ct1.barrier(sycl::access::fence_space::local_space);
+                item_ct1.barrier(SYCL_MEMORY_SPACE);
         } // End rotation_counter for-loop
 
 	// ================================================
@@ -470,7 +470,7 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
         DPC++ Compatibility Tool.
         */
         __threadfence();
-        item_ct1.barrier(sycl::access::fence_space::local_space);
+        item_ct1.barrier(SYCL_MEMORY_SPACE);
 
         // Inter- and intra-molecular energy calculation
 	// are independent from each other, so NO barrier is needed here.
@@ -682,7 +682,7 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
         DPC++ Compatibility Tool.
         */
         __threadfence();
-        item_ct1.barrier(sycl::access::fence_space::local_space);
+        item_ct1.barrier(SYCL_MEMORY_SPACE);
 
         // Transform gradients_inter_{x|y|z} 
 	// into local_gradients[i] (with four quaternion genes)
@@ -833,7 +833,7 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
         DPC++ Compatibility Tool.
         */
         __threadfence();
-        item_ct1.barrier(sycl::access::fence_space::local_space);
+        item_ct1.barrier(SYCL_MEMORY_SPACE);
 
         // ------------------------------------------
 	// Obtaining rotation-related gradients
@@ -1057,7 +1057,7 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
         DPC++ Compatibility Tool.
         */
         __threadfence();
-        item_ct1.barrier(sycl::access::fence_space::local_space);
+        item_ct1.barrier(SYCL_MEMORY_SPACE);
 
         // ------------------------------------------
 	// Obtaining torsion-related gradients
@@ -1148,7 +1148,7 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
         DPC++ Compatibility Tool.
         */
         __threadfence();
-        item_ct1.barrier(sycl::access::fence_space::local_space);
+        item_ct1.barrier(SYCL_MEMORY_SPACE);
 
         for (uint32_t gene_cnt = item_ct1.get_local_id(2);
              gene_cnt < cData.dockpars.num_of_genes;
@@ -1160,7 +1160,7 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
         DPC++ Compatibility Tool.
         */
         __threadfence();
-        item_ct1.barrier(sycl::access::fence_space::local_space);
+        item_ct1.barrier(SYCL_MEMORY_SPACE);
 
 #if defined (CONVERT_INTO_ANGSTROM_RADIAN)
         for (uint32_t gene_cnt =
@@ -1176,6 +1176,6 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
         DPC++ Compatibility Tool.
         */
         __threadfence();
-        item_ct1.barrier(sycl::access::fence_space::local_space);
+        item_ct1.barrier(SYCL_MEMORY_SPACE);
 #endif
 }

--- a/dpcpp/calcMergeEneGra.dp.cpp
+++ b/dpcpp/calcMergeEneGra.dp.cpp
@@ -1,6 +1,5 @@
 #include <CL/sycl.hpp>
 #include <dpct/dpct.hpp>
-
 /*
 
 AutoDock-GPU, an OpenCL implementation of AutoDock 4.2 running a Lamarckian

--- a/dpcpp/calcMergeEneGra.dp.cpp
+++ b/dpcpp/calcMergeEneGra.dp.cpp
@@ -145,7 +145,7 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
         DPC++ Compatibility Tool.
         */
         __threadfence();
-        item_ct1.barrier();
+        item_ct1.barrier(sycl::access::fence_space::local_space);
 
         // ================================================
 	// CALCULATING ATOMIC POSITIONS AFTER ROTATIONS
@@ -236,7 +236,7 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
                 Intel(R) DPC++ Compatibility Tool.
                 */
                 __threadfence();
-                item_ct1.barrier();
+                item_ct1.barrier(sycl::access::fence_space::local_space);
         } // End rotation_counter for-loop
 
 	// ================================================
@@ -470,7 +470,7 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
         DPC++ Compatibility Tool.
         */
         __threadfence();
-        item_ct1.barrier();
+        item_ct1.barrier(sycl::access::fence_space::local_space);
 
         // Inter- and intra-molecular energy calculation
 	// are independent from each other, so NO barrier is needed here.
@@ -682,7 +682,7 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
         DPC++ Compatibility Tool.
         */
         __threadfence();
-        item_ct1.barrier();
+        item_ct1.barrier(sycl::access::fence_space::local_space);
 
         // Transform gradients_inter_{x|y|z} 
 	// into local_gradients[i] (with four quaternion genes)
@@ -833,7 +833,7 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
         DPC++ Compatibility Tool.
         */
         __threadfence();
-        item_ct1.barrier();
+        item_ct1.barrier(sycl::access::fence_space::local_space);
 
         // ------------------------------------------
 	// Obtaining rotation-related gradients
@@ -1057,7 +1057,7 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
         DPC++ Compatibility Tool.
         */
         __threadfence();
-        item_ct1.barrier();
+        item_ct1.barrier(sycl::access::fence_space::local_space);
 
         // ------------------------------------------
 	// Obtaining torsion-related gradients
@@ -1148,7 +1148,7 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
         DPC++ Compatibility Tool.
         */
         __threadfence();
-        item_ct1.barrier();
+        item_ct1.barrier(sycl::access::fence_space::local_space);
 
         for (uint32_t gene_cnt = item_ct1.get_local_id(2);
              gene_cnt < cData.dockpars.num_of_genes;
@@ -1160,7 +1160,7 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
         DPC++ Compatibility Tool.
         */
         __threadfence();
-        item_ct1.barrier();
+        item_ct1.barrier(sycl::access::fence_space::local_space);
 
 #if defined (CONVERT_INTO_ANGSTROM_RADIAN)
         for (uint32_t gene_cnt =
@@ -1176,6 +1176,6 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
         DPC++ Compatibility Tool.
         */
         __threadfence();
-        item_ct1.barrier();
+        item_ct1.barrier(sycl::access::fence_space::local_space);
 #endif
 }

--- a/dpcpp/calcenergy.dp.cpp
+++ b/dpcpp/calcenergy.dp.cpp
@@ -1,6 +1,6 @@
 #include <CL/sycl.hpp>
 #include <dpct/dpct.hpp>
-#include "defines.h"
+
 /*
 
 AutoDock-GPU, an OpenCL implementation of AutoDock 4.2 running a Lamarckian
@@ -180,7 +180,7 @@ SYCL_EXTERNAL void gpu_calc_energy(float *pGenotype, float &energy, int &run_id,
         DPC++ Compatibility Tool.
         */
         __threadfence();
-        item_ct1.barrier(sycl::access::fence_space::local_space);
+        item_ct1.barrier(SYCL_MEMORY_SPACE);
 
         // ================================================
 	// CALCULATING ATOMIC POSITIONS AFTER ROTATIONS
@@ -270,7 +270,7 @@ SYCL_EXTERNAL void gpu_calc_energy(float *pGenotype, float &energy, int &run_id,
                 Intel(R) DPC++ Compatibility Tool.
                 */
                 __threadfence();
-                item_ct1.barrier(sycl::access::fence_space::local_space);
+                item_ct1.barrier(SYCL_MEMORY_SPACE);
 
         } // End rotation_counter for-loop
 

--- a/dpcpp/calcenergy.dp.cpp
+++ b/dpcpp/calcenergy.dp.cpp
@@ -1,6 +1,5 @@
 #include <CL/sycl.hpp>
 #include <dpct/dpct.hpp>
-
 /*
 
 AutoDock-GPU, an OpenCL implementation of AutoDock 4.2 running a Lamarckian

--- a/dpcpp/kernel3.dp.cpp
+++ b/dpcpp/kernel3.dp.cpp
@@ -105,7 +105,7 @@ gpu_perform_LS_kernel(
         DPC++ Compatibility Tool.
         */
         __threadfence();
-        item_ct1.barrier(sycl::access::fence_space::local_space);
+        item_ct1.barrier(SYCL_MEMORY_SPACE);
 
         size_t offset = (run_id * cData.dockpars.pop_size + *entity_id) *
                         GENOTYPE_LENGTH_IN_GLOBMEM;
@@ -121,7 +121,7 @@ gpu_perform_LS_kernel(
         DPC++ Compatibility Tool.
         */
         __threadfence();
-        item_ct1.barrier(sycl::access::fence_space::local_space);
+        item_ct1.barrier(SYCL_MEMORY_SPACE);
 
 #ifdef SWAT3
         float lig_scale = 1.0f / sycl::sqrt((float)cData.dockpars.num_of_atoms);
@@ -185,7 +185,7 @@ gpu_perform_LS_kernel(
                 Intel(R) DPC++ Compatibility Tool.
                 */
                 __threadfence();
-                item_ct1.barrier(sycl::access::fence_space::local_space);
+                item_ct1.barrier(SYCL_MEMORY_SPACE);
 
                 // =================================================================
                 gpu_calc_energy(genotype_candidate, candidate_energy, run_id,
@@ -200,7 +200,7 @@ gpu_perform_LS_kernel(
                 Intel(R) DPC++ Compatibility Tool.
                 */
                 __threadfence();
-                item_ct1.barrier(sycl::access::fence_space::local_space);
+                item_ct1.barrier(SYCL_MEMORY_SPACE);
 
                 if (candidate_energy < *offspring_energy) // If candidate is better, success
                 {
@@ -221,7 +221,7 @@ gpu_perform_LS_kernel(
                         by the Intel(R) DPC++ Compatibility Tool.
                         */
                         __threadfence();
-                        item_ct1.barrier(sycl::access::fence_space::local_space);
+                        item_ct1.barrier(SYCL_MEMORY_SPACE);
 
                         if (item_ct1.get_local_id(2) == 0)
                         {
@@ -248,7 +248,7 @@ gpu_perform_LS_kernel(
                         by the Intel(R) DPC++ Compatibility Tool.
                         */
                         __threadfence();
-                        item_ct1.barrier(sycl::access::fence_space::local_space);
+                        item_ct1.barrier(SYCL_MEMORY_SPACE);
 
                         // =================================================================
                         gpu_calc_energy(genotype_candidate, candidate_energy,
@@ -268,7 +268,7 @@ gpu_perform_LS_kernel(
                         by the Intel(R) DPC++ Compatibility Tool.
                         */
                         __threadfence();
-                        item_ct1.barrier(sycl::access::fence_space::local_space);
+                        item_ct1.barrier(SYCL_MEMORY_SPACE);
 
                         if (candidate_energy < *offspring_energy) // If candidate is better, success
                         {
@@ -292,7 +292,7 @@ gpu_perform_LS_kernel(
                                 Tool.
                                 */
                                 __threadfence();
-                                item_ct1.barrier(sycl::access::fence_space::local_space);
+                                item_ct1.barrier(SYCL_MEMORY_SPACE);
 
                                 if (item_ct1.get_local_id(2) == 0)
                                 {
@@ -339,7 +339,7 @@ gpu_perform_LS_kernel(
                 Intel(R) DPC++ Compatibility Tool.
                 */
                 __threadfence();
-                item_ct1.barrier(sycl::access::fence_space::local_space);
+                item_ct1.barrier(SYCL_MEMORY_SPACE);
         }
 
 	// Updating eval counter and energy

--- a/dpcpp/kernel3.dp.cpp
+++ b/dpcpp/kernel3.dp.cpp
@@ -124,8 +124,8 @@ gpu_perform_LS_kernel(
         item_ct1.barrier(SYCL_MEMORY_SPACE);
 
 #ifdef SWAT3
-        float lig_scale = 1.0f / sycl::sqrt((float)cData.dockpars.num_of_atoms);
-        float gene_scale = 1.0f / sycl::sqrt((float)cData.dockpars.num_of_genes);
+		float lig_scale = SYCL_RSQRT((float)cData.dockpars.num_of_atoms);
+		float gene_scale = SYCL_RSQRT((float)cData.dockpars.num_of_genes);
 #endif
         while ((*iteration_cnt < cData.dockpars.max_num_of_iters) &&
                (*rho > cData.dockpars.rho_lower_bound))

--- a/dpcpp/kernel4.dp.cpp
+++ b/dpcpp/kernel4.dp.cpp
@@ -116,7 +116,7 @@ gpu_gen_and_eval_newpops_kernel(
                 Intel(R) DPC++ Compatibility Tool.
                 */
                 __threadfence();
-                item_ct1.barrier(sycl::access::fence_space::local_space);
+                item_ct1.barrier(SYCL_MEMORY_SPACE);
 
                 // Perform final reduction in warp 0
 		if (warpID == 0)
@@ -146,7 +146,7 @@ gpu_gen_and_eval_newpops_kernel(
                 Intel(R) DPC++ Compatibility Tool.
                 */
                 __threadfence();
-                item_ct1.barrier(sycl::access::fence_space::local_space);
+                item_ct1.barrier(SYCL_MEMORY_SPACE);
 
                 // Copy best genome to next generation
                 int dOffset = item_ct1.get_group(2) * GENOTYPE_LENGTH_IN_GLOBMEM;
@@ -186,7 +186,7 @@ gpu_gen_and_eval_newpops_kernel(
                 Intel(R) DPC++ Compatibility Tool.
                 */
                 __threadfence();
-                item_ct1.barrier(sycl::access::fence_space::local_space);
+                item_ct1.barrier(SYCL_MEMORY_SPACE);
 
                 if (item_ct1.get_local_id(2) <
                     4) // it is not ensured that the four candidates will be
@@ -206,7 +206,7 @@ gpu_gen_and_eval_newpops_kernel(
                 Intel(R) DPC++ Compatibility Tool.
                 */
                 __threadfence();
-                item_ct1.barrier(sycl::access::fence_space::local_space);
+                item_ct1.barrier(SYCL_MEMORY_SPACE);
 
                 if (item_ct1.get_local_id(2) < 2)
                 {
@@ -254,7 +254,7 @@ gpu_gen_and_eval_newpops_kernel(
                 Intel(R) DPC++ Compatibility Tool.
                 */
                 __threadfence();
-                item_ct1.barrier(sycl::access::fence_space::local_space);
+                item_ct1.barrier(SYCL_MEMORY_SPACE);
 
                 // Performing crossover
 		// Notice: dockpars_crossover_rate was scaled down to [0,1] in host
@@ -273,7 +273,7 @@ gpu_gen_and_eval_newpops_kernel(
                         by the Intel(R) DPC++ Compatibility Tool.
                         */
                         __threadfence();
-                        item_ct1.barrier(sycl::access::fence_space::local_space);
+                        item_ct1.barrier(SYCL_MEMORY_SPACE);
 
                         // covr_point[0] should store the lower crossover-point
                         if (item_ct1.get_local_id(2) == 0) {
@@ -289,7 +289,7 @@ gpu_gen_and_eval_newpops_kernel(
                         by the Intel(R) DPC++ Compatibility Tool.
                         */
                         __threadfence();
-                        item_ct1.barrier(sycl::access::fence_space::local_space);
+                        item_ct1.barrier(SYCL_MEMORY_SPACE);
 
                         for (uint32_t gene_counter = item_ct1.get_local_id(2);
                              gene_counter < cData.dockpars.num_of_genes;
@@ -328,7 +328,7 @@ gpu_gen_and_eval_newpops_kernel(
                 Intel(R) DPC++ Compatibility Tool.
                 */
                 __threadfence();
-                item_ct1.barrier(sycl::access::fence_space::local_space);
+                item_ct1.barrier(SYCL_MEMORY_SPACE);
 
                 // Performing mutation
                 for (uint32_t gene_counter = item_ct1.get_local_id(2);
@@ -370,7 +370,7 @@ gpu_gen_and_eval_newpops_kernel(
                 Intel(R) DPC++ Compatibility Tool.
                 */
                 __threadfence();
-                item_ct1.barrier(sycl::access::fence_space::local_space);
+                item_ct1.barrier(SYCL_MEMORY_SPACE);
 
                 gpu_calc_energy(offspring_genotype, energy, run_id, calc_coords,
                                 sFloatAccumulator, item_ct1, cData);

--- a/dpcpp/kernel_ad.dp.cpp
+++ b/dpcpp/kernel_ad.dp.cpp
@@ -159,7 +159,7 @@ gpu_gradient_minAD_kernel(
         DPC++ Compatibility Tool.
         */
         __threadfence();
-        item_ct1.barrier(sycl::access::fence_space::local_space);
+        item_ct1.barrier(SYCL_MEMORY_SPACE);
         energy = pMem_energies_next[run_id * cData.dockpars.pop_size + *entity_id];
 
         int offset = (run_id * cData.dockpars.pop_size + *entity_id) *
@@ -190,7 +190,7 @@ gpu_gradient_minAD_kernel(
         DPC++ Compatibility Tool.
         */
         __threadfence();
-        item_ct1.barrier(sycl::access::fence_space::local_space);
+        item_ct1.barrier(SYCL_MEMORY_SPACE);
 
         // Initializing vectors
         for (uint32_t i = item_ct1.get_local_id(2);
@@ -246,7 +246,7 @@ gpu_gradient_minAD_kernel(
                 Intel(R) DPC++ Compatibility Tool.
                 */
                 __threadfence();
-                item_ct1.barrier(sycl::access::fence_space::local_space);
+                item_ct1.barrier(SYCL_MEMORY_SPACE);
 
                 gpu_calc_energrad(
                     // Some OpenCL compilers don't allow declaring
@@ -333,7 +333,7 @@ gpu_gradient_minAD_kernel(
                 Intel(R) DPC++ Compatibility Tool.
                 */
                 __threadfence();
-                item_ct1.barrier(sycl::access::fence_space::local_space);
+                item_ct1.barrier(SYCL_MEMORY_SPACE);
 
 #if defined (DEBUG_SQDELTA_ADADELTA)
 		if (/*(get_group_id(0) == 0) &&*/ (threadIdx.x == 0)) {
@@ -396,7 +396,7 @@ gpu_gradient_minAD_kernel(
                 Intel(R) DPC++ Compatibility Tool.
                 */
                 __threadfence();
-                item_ct1.barrier(sycl::access::fence_space::local_space); // making sure that iteration_cnt is up-to-date
+                item_ct1.barrier(SYCL_MEMORY_SPACE); // making sure that iteration_cnt is up-to-date
 #ifdef ADADELTA_AUTOSTOP
         } while ((iteration_cnt < cData.dockpars.max_num_of_iters) && (*rho > 0.01f));
 #else
@@ -419,7 +419,7 @@ gpu_gradient_minAD_kernel(
         DPC++ Compatibility Tool.
         */
         __threadfence();
-        item_ct1.barrier(sycl::access::fence_space::local_space);
+        item_ct1.barrier(SYCL_MEMORY_SPACE);
 
         offset = (run_id * cData.dockpars.pop_size + *entity_id) *
                  GENOTYPE_LENGTH_IN_GLOBMEM;

--- a/dpcpp/kernel_ad.dp.cpp
+++ b/dpcpp/kernel_ad.dp.cpp
@@ -318,8 +318,7 @@ gpu_gradient_minAD_kernel(
 			// Computing update (eq.9 in the paper)
                         float delta =
                             -1.0f * gradient[i] *
-                            sycl::sqrt((float)(square_delta[i] + EPSILON) /
-                                       (float)(square_gradient[i] + EPSILON));
+								SYCL_SQRT(SYCL_DIVIDE((float)(square_delta[i] + EPSILON), (float)(square_gradient[i] + EPSILON)));
 
                         // Accumulating update^2
 			// square_delta corresponds to E[dx^2]

--- a/dpcpp/kernel_adam.dp.cpp
+++ b/dpcpp/kernel_adam.dp.cpp
@@ -145,7 +145,7 @@ gpu_gradient_minAdam_kernel(
 		printf("%20s %.6f\n", "initial energy: ", energy);
 		#endif
 	}
-        item_ct1.barrier(sycl::access::fence_space::local_space);
+        item_ct1.barrier(SYCL_MEMORY_SPACE);
         /*
         DPCT1007:75: Migration of this CUDA API is not supported by the Intel(R)
         DPC++ Compatibility Tool.
@@ -185,7 +185,7 @@ gpu_gradient_minAdam_kernel(
         DPC++ Compatibility Tool.
         */
         __threadfence();
-        item_ct1.barrier(sycl::access::fence_space::local_space);
+        item_ct1.barrier(SYCL_MEMORY_SPACE);
 
         // Enable this for debugging ADADELTA from a defined initial genotype
 
@@ -241,7 +241,7 @@ gpu_gradient_minAdam_kernel(
                 Intel(R) DPC++ Compatibility Tool.
                 */
                 __threadfence();
-                item_ct1.barrier(sycl::access::fence_space::local_space);
+                item_ct1.barrier(SYCL_MEMORY_SPACE);
 
                 gpu_calc_energrad(genotype, energy, run_id, calc_coords,
 #if defined (DEBUG_ENERGY_KERNEL)
@@ -334,7 +334,7 @@ gpu_gradient_minAdam_kernel(
                 Intel(R) DPC++ Compatibility Tool.
                 */
                 __threadfence();
-                item_ct1.barrier(sycl::access::fence_space::local_space);
+                item_ct1.barrier(SYCL_MEMORY_SPACE);
 
 #if defined (DEBUG_SQDELTA_ADADELTA)
 		if (/*(get_group_id(0) == 0) &&*/ (threadIdx.x == 0)) {
@@ -397,7 +397,7 @@ gpu_gradient_minAdam_kernel(
                 Intel(R) DPC++ Compatibility Tool.
                 */
                 __threadfence();
-                item_ct1.barrier(sycl::access::fence_space::local_space); // making sure that iteration_cnt is up-to-date
+                item_ct1.barrier(SYCL_MEMORY_SPACE); // making sure that iteration_cnt is up-to-date
 #ifdef AD_RHO_CRITERION
 	} while ((iteration_cnt < cData.dockpars.max_num_of_iters)  && (rho > 0.01f));
 #else
@@ -421,7 +421,7 @@ gpu_gradient_minAdam_kernel(
         DPC++ Compatibility Tool.
         */
         __threadfence();
-        item_ct1.barrier(sycl::access::fence_space::local_space);
+        item_ct1.barrier(SYCL_MEMORY_SPACE);
 
         offset = (run_id * cData.dockpars.pop_size + *entity_id) *
                  GENOTYPE_LENGTH_IN_GLOBMEM;

--- a/dpcpp/kernel_adam.dp.cpp
+++ b/dpcpp/kernel_adam.dp.cpp
@@ -327,7 +327,7 @@ gpu_gradient_minAdam_kernel(
 			float vp = vt[i] / beta2p;
 
 			// Applying update
-                        genotype[i] -= mp / (sycl::sqrt(vp) + cData.dockpars.adam_epsilon);
+                        genotype[i] -= mp / (SYCL_SQRT(vp) + cData.dockpars.adam_epsilon);
                 }
                 /*
                 DPCT1007:79: Migration of this CUDA API is not supported by the

--- a/dpcpp/kernel_adam.dp.cpp
+++ b/dpcpp/kernel_adam.dp.cpp
@@ -323,11 +323,11 @@ gpu_gradient_minAdam_kernel(
 			// Update Adam parameters
 			mt[i] = cData.dockpars.adam_beta1 * mt[i] + (1.0f - cData.dockpars.adam_beta1) * gradient[i];
 			vt[i] = cData.dockpars.adam_beta2 * vt[i] + (1.0f - cData.dockpars.adam_beta2) * gradient[i] * gradient[i];
-			float mp = mt[i] / beta1p;
-			float vp = vt[i] / beta2p;
+			float mp = SYCL_DIVIDE(mt[i], beta1p);
+			float vp = SYCL_DIVIDE(vt[i], beta2p);
 
 			// Applying update
-                        genotype[i] -= mp / (SYCL_SQRT(vp) + cData.dockpars.adam_epsilon);
+                        genotype[i] -= SYCL_DIVIDE(mp, (SYCL_SQRT(vp) + cData.dockpars.adam_epsilon));
                 }
                 /*
                 DPCT1007:79: Migration of this CUDA API is not supported by the

--- a/dpcpp/kernels.dp.cpp
+++ b/dpcpp/kernels.dp.cpp
@@ -90,7 +90,7 @@ Compatibility Tool.
 #define REDUCEINTEGERSUM(value, pAccumulator)                                          \
         int val = sycl::reduce_over_group(item_ct1.get_group(), value, std::plus<>()); \
         *pAccumulator = val;                                                           \
-        item_ct1.barrier(sycl::access::fence_space::local_space);
+        item_ct1.barrier(SYCL_MEMORY_SPACE);
 
 #define ATOMICADDI32(pAccumulator, value)                               \
         sycl::atomic_ref<int, sycl::memory_order::acq_rel, sycl::memory_scope::device, sycl::access::address_space::local_space>(*pAccumulator) += ((int) (value))
@@ -130,7 +130,7 @@ Compatibility Tool.
 #define REDUCEFLOATSUM(value, pAccumulator) \
         value = sycl::reduce_over_group(item_ct1.get_group(), value, std::plus<>());\
         *pAccumulator = (float) value;\
-        item_ct1.barrier(sycl::access::fence_space::local_space);
+        item_ct1.barrier(SYCL_MEMORY_SPACE);
 
 
 static dpct::constant_memory<GpuData, 0> cData;


### PR DESCRIPTION
This PR adds the `SYCL_LOCAL_BARRIER` macro to switch between local and global memory for barriers.

Also, this PR adds native support to some calls (missed in PR https://github.com/emascarenhas/AutoDock-GPU/pull/1) in kernels Solis-Wets, ADADELTA, and ADAM.
