### PR TITLE
Enabling RNG based on oneMKL `generate_single`

### DIFF
--- a/dpcpp/kernel3.dp.cpp
+++ b/dpcpp/kernel3.dp.cpp
@@ -54,7 +54,7 @@ gpu_perform_LS_kernel(
                       int *entity_id
 						#if !defined (RNG_ORIGINAL)
 						,
-						RNG_ONEMKL_TYPE* rng_engine,
+						RNG_ONEMKL_ENGINE_TYPE* rng_engine,
 						oneapi::mkl::rng::device::uniform<float>* rng_continuous_distr
 						#endif
 )
@@ -439,7 +439,7 @@ void gpu_perform_LS(
 							// Creating an RNG engine object
 							uint64_t rng_seed = cData_ptr_ct1->pMem_prng_states[item_ct1.get_global_id(2)];
 							uint64_t rng_offset = item_ct1.get_local_id(2) * threads;
-							RNG_ONEMKL_TYPE rng_engine(rng_seed, rng_offset);
+							RNG_ONEMKL_ENGINE_TYPE rng_engine(rng_seed, rng_offset);
 
 							// Creating a continuous RNG distribution object
 							oneapi::mkl::rng::device::uniform<float> rng_continuous_distr;

--- a/dpcpp/kernel3.dp.cpp
+++ b/dpcpp/kernel3.dp.cpp
@@ -55,7 +55,7 @@ gpu_perform_LS_kernel(
 						#if !defined (RNG_ORIGINAL)
 						,
 						RNG_ONEMKL_ENGINE_TYPE* rng_engine,
-						oneapi::mkl::rng::device::uniform<float>* rng_continuous_distr
+						RNG_ONEMKL_DISTRIBUTION_TYPE* rng_continuous_distr
 						#endif
 )
 // The GPU global function performs local search on the pre-defined entities of conformations_next.
@@ -442,7 +442,7 @@ void gpu_perform_LS(
 							RNG_ONEMKL_ENGINE_TYPE rng_engine(rng_seed, rng_offset);
 
 							// Creating a continuous RNG distribution object
-							oneapi::mkl::rng::device::uniform<float> rng_continuous_distr;
+							RNG_ONEMKL_DISTRIBUTION_TYPE rng_continuous_distr;
 							#endif
 
                             gpu_perform_LS_kernel(

--- a/dpcpp/kernel3.dp.cpp
+++ b/dpcpp/kernel3.dp.cpp
@@ -89,8 +89,8 @@ gpu_perform_LS_kernel(
                         // If entity 0 is not selected according to LS-rate,
 			// choosing an other entity
                         if (100.0f *
-                                gpu_randf(cData.pMem_prng_states, item_ct1) >
-                            cData.dockpars.lsearch_rate) {
+//                                gpu_randf(cData.pMem_prng_states, item_ct1) > cData.dockpars.lsearch_rate) {
+								oneapi::mkl::rng::device::generate_single(*rng_continuous_distr, *rng_engine) > cData.dockpars.lsearch_rate) {
                                 *entity_id = cData.dockpars.num_of_lsentities;
                         }
 		}
@@ -142,11 +142,10 @@ gpu_perform_LS_kernel(
 #ifdef SWAT3
                         genotype_deviate[gene_counter] =
                             *rho *
-                            (2.0f *
-                                 gpu_randf(cData.pMem_prng_states, item_ct1) -
-                             1.0f) *
-                            (gpu_randf(cData.pMem_prng_states, item_ct1) <
-                             gene_scale);
+//                            (2.0f * gpu_randf(cData.pMem_prng_states, item_ct1) - 1.0f) *
+//                            (gpu_randf(cData.pMem_prng_states, item_ct1) < gene_scale);
+                            (2.0f * oneapi::mkl::rng::device::generate_single(*rng_continuous_distr, *rng_engine) - 1.0f) *
+                            (oneapi::mkl::rng::device::generate_single(*rng_continuous_distr, *rng_engine) < gene_scale);
 
                         // Translation genes
 			if (gene_counter < 3) {
@@ -161,7 +160,8 @@ gpu_perform_LS_kernel(
 				}
 			}
 #else
-			genotype_deviate[gene_counter] = rho*(2.0f*gpu_randf(cData.pMem_prng_states)-1.0f)*(gpu_randf(cData.pMem_prng_states)<0.3f);
+//			genotype_deviate[gene_counter] = rho*(2.0f*gpu_randf(cData.pMem_prng_states)-1.0f)*(gpu_randf(cData.pMem_prng_states)<0.3f);
+			genotype_deviate[gene_counter] = rho*(2.0f*oneapi::mkl::rng::device::generate_single(*rng_continuous_distr, *rng_engine)-1.0f)*(oneapi::mkl::rng::device::generate_single(*rng_continuous_distr, *rng_engine)<0.3f);
 
 			// Translation genes
 			if (gene_counter < 3) {

--- a/dpcpp/kernel3.dp.cpp
+++ b/dpcpp/kernel3.dp.cpp
@@ -53,7 +53,7 @@ gpu_perform_LS_kernel(
                       float *sFloatAccumulator,
                       int *entity_id
 						,
-						oneapi::mkl::rng::device::philox4x32x10<64>* rng_engine,
+						oneapi::mkl::rng::device::philox4x32x10<16>* rng_engine,
 						oneapi::mkl::rng::device::uniform<float>* rng_continuous_distr
 )
 // The GPU global function performs local search on the pre-defined entities of conformations_next.
@@ -427,7 +427,7 @@ void gpu_perform_LS(
 							// Creating an RNG engine object
 							uint64_t rng_seed = cData_ptr_ct1->pMem_prng_states[item_ct1.get_global_id(2)];
 							uint64_t rng_offset = item_ct1.get_local_id(2) * threads;
-							oneapi::mkl::rng::device::philox4x32x10<64> rng_engine(rng_seed, rng_offset);
+							oneapi::mkl::rng::device::philox4x32x10<16> rng_engine(rng_seed, rng_offset);
 
 							// Creating a continuous RNG distribution object
 							oneapi::mkl::rng::device::uniform<float> rng_continuous_distr;

--- a/dpcpp/kernel4.dp.cpp
+++ b/dpcpp/kernel4.dp.cpp
@@ -170,20 +170,19 @@ gpu_gen_and_eval_newpops_kernel(
 		// [0..3] for parent candidates,
 		// [4..5] for binary tournaments, [6] for deciding crossover,
 		// [7..8] for crossover points, [9] for local search
-		float meme[10];
                 for (uint32_t gene_counter = item_ct1.get_local_id(2);
                      gene_counter < 10;
                      gene_counter += item_ct1.get_local_range().get(2))
                 {
-                        randnums[gene_counter] = gpu_randf(cData.pMem_prng_states, item_ct1);
-						/*randnums[gene_counter]*/ meme[gene_counter] = oneapi::mkl::rng::device::generate_single(*rng_continuous_distr, *rng_engine);
+                        //randnums[gene_counter] = gpu_randf(cData.pMem_prng_states, item_ct1);
+						randnums[gene_counter] = oneapi::mkl::rng::device::generate_single(*rng_continuous_distr, *rng_engine);
                 }
 
 		item_ct1.barrier(SYCL_MEMORY_SPACE);
 		if ( (item_ct1.get_group(2) == 1) && (item_ct1.get_local_id(2) == 0) ) {
 			PRINTF("\nLocal work-item id: %d\n", item_ct1.get_local_id(2));
 			for (uint32_t j = 0; j < 10; j++) {
-				PRINTF("[%d]: gpu_randf=%2.4f, onemkl_rng=%2.4f\n", j, randnums[j], meme[j]);
+				PRINTF("randnums[%d]=%2.4f\n", j, randnums[j]);
 			}
 		}
 		item_ct1.barrier(SYCL_MEMORY_SPACE);

--- a/dpcpp/kernel4.dp.cpp
+++ b/dpcpp/kernel4.dp.cpp
@@ -182,7 +182,7 @@ gpu_gen_and_eval_newpops_kernel(
 		item_ct1.barrier(SYCL_MEMORY_SPACE);
 		if ( (item_ct1.get_group(2) == 1) && item_ct1.get_local_id(2) == 0 ) {
 			for (uint32_t j = 0; j < 10; j++) {
-				PRINTF("[%d]: gpu_randf=%2.4f \t onemkl::rng=%2.4f", j, randnums[j], meme[j]);
+				PRINTF("[%d]: gpu_randf=%2.4f \t onemkl::rng=%2.4f\n", j, randnums[j], meme[j]);
 			}
 			PRINTF("\n", "");
 		}

--- a/dpcpp/kernel4.dp.cpp
+++ b/dpcpp/kernel4.dp.cpp
@@ -467,6 +467,16 @@ void gpu_gen_and_eval_newpops(
                                       sycl::range<3>(1, 1, threadsPerBlock)),
                     [=](sycl::nd_item<3> item_ct1) 
                     [[intel::reqd_sub_group_size(32)]] {
+
+							// Creating an RNG engine object
+							const int32_t rng_VecSize = ACTUAL_GENOTYPE_LENGTH;
+							uint64_t rng_seed = cData_ptr_ct1->pMem_prng_states[0];
+							uint64_t rng_offset = item_ct1.get_local_id(2) * rng_VecSize;
+							oneapi::mkl::rng::device::philox4x32x10<rng_VecSize> rng_engine(rng_seed, rng_offset);
+
+							// Creating an RNG distribution object
+							oneapi::mkl::rng::device::uniform<> rng_distr;
+
                             gpu_gen_and_eval_newpops_kernel(
                                 pMem_conformations_current,
                                 pMem_energies_current, pMem_conformations_next,

--- a/dpcpp/kernel4.dp.cpp
+++ b/dpcpp/kernel4.dp.cpp
@@ -182,7 +182,7 @@ gpu_gen_and_eval_newpops_kernel(
 		item_ct1.barrier(SYCL_MEMORY_SPACE);
 		if ( (item_ct1.get_group(2) == 1) && item_ct1.get_local_id(2) == 0 ) {
 			for (uint32_t j = 0; j < 10; j++) {
-				PRINTF("[%d]: gpu_randf=%2.4f \t onemkl::rng=%2.4f\n", j, randnums[j], meme[j]);
+				PRINTF("[%d]: gpu_randf=%2.4f	|	onemkl::rng=%2.4f\n", j, randnums[j], meme[j]);
 			}
 			PRINTF("\n", "");
 		}

--- a/dpcpp/kernel4.dp.cpp
+++ b/dpcpp/kernel4.dp.cpp
@@ -178,6 +178,7 @@ gpu_gen_and_eval_newpops_kernel(
 						randnums[gene_counter] = oneapi::mkl::rng::device::generate_single(*rng_continuous_distr, *rng_engine);
                 }
 
+#if 0
 		item_ct1.barrier(SYCL_MEMORY_SPACE);
 		if ( (item_ct1.get_group(2) == 1) && (item_ct1.get_local_id(2) == 0) ) {
 			PRINTF("\nLocal work-item id: %d\n", item_ct1.get_local_id(2));
@@ -186,16 +187,8 @@ gpu_gen_and_eval_newpops_kernel(
 			}
 		}
 		item_ct1.barrier(SYCL_MEMORY_SPACE);
-
-#if 0
-		if ((threadIdx.x == 0) && (blockIdx.x == 1))
-		{
-			printf("%06d ", blockIdx.x);
-			for (int i = 0; i < 10; i++)
-				printf("%12.6f ", randnums[i]);
-			printf("\n");
-		}
 #endif
+
 		// Determining run ID
                 run_id = item_ct1.get_group(2) / cData.dockpars.pop_size;
                 /*

--- a/dpcpp/kernel4.dp.cpp
+++ b/dpcpp/kernel4.dp.cpp
@@ -64,7 +64,7 @@ gpu_gen_and_eval_newpops_kernel(
                                 float *sFloatAccumulator
 								#if !defined (RNG_ORIGINAL)
 								,
-								RNG_ONEMKL_TYPE* rng_engine,
+								RNG_ONEMKL_ENGINE_TYPE* rng_engine,
 								oneapi::mkl::rng::device::uniform<float>* rng_continuous_distr
 								#endif
 								)
@@ -490,7 +490,7 @@ void gpu_gen_and_eval_newpops(
 							// Creating an RNG engine object
 							uint64_t rng_seed = cData_ptr_ct1->pMem_prng_states[item_ct1.get_global_id(2)];
 							uint64_t rng_offset = item_ct1.get_local_id(2) * threadsPerBlock;
-							RNG_ONEMKL_TYPE rng_engine(rng_seed, rng_offset);
+							RNG_ONEMKL_ENGINE_TYPE rng_engine(rng_seed, rng_offset);
 
 							// Creating a continuous RNG distribution object
 							oneapi::mkl::rng::device::uniform<float> rng_continuous_distr;

--- a/dpcpp/kernel4.dp.cpp
+++ b/dpcpp/kernel4.dp.cpp
@@ -63,15 +63,7 @@ gpu_gen_and_eval_newpops_kernel(
                                 sycl::float3 *calc_coords,
                                 float *sFloatAccumulator
 								,
-								#if defined(RNG_ONEMKL_MRG32K3A)
-								oneapi::mkl::rng::device::mrg32k3a<16>* rng_engine,
-								#elif defined (RNG_ONEMKL_PHILOX4X32X10)
-								oneapi::mkl::rng::device::philox4x32x10<16>* rng_engine,
-								#elif defined (RNG_ONEMKL_MCG31M1)
-								oneapi::mkl::rng::device::mcg31m1<16>* rng_engine,
-								#elif defined (RNG_ONEMKL_MCG59)
-								oneapi::mkl::rng::device::mcg59<16>* rng_engine,
-								#endif
+								RNG_ONEMKL_TYPE* rng_engine,
 								oneapi::mkl::rng::device::uniform<float>* rng_continuous_distr
 								)
 // The GPU global function
@@ -483,15 +475,7 @@ void gpu_gen_and_eval_newpops(
 							// Creating an RNG engine object
 							uint64_t rng_seed = cData_ptr_ct1->pMem_prng_states[item_ct1.get_global_id(2)];
 							uint64_t rng_offset = item_ct1.get_local_id(2) * threadsPerBlock;
-							#if defined (RNG_ONEMKL_MRG32K3A)
-							oneapi::mkl::rng::device::mrg32k3a<16> rng_engine(rng_seed, rng_offset);
-							#elif defined (RNG_ONEMKL_PHILOX4X32X10)
-							oneapi::mkl::rng::device::philox4x32x10<16> rng_engine(rng_seed, rng_offset);
-							#elif defined (RNG_ONEMKL_MCG31M1)
-							oneapi::mkl::rng::device::mcg31m1<16> rng_engine(rng_seed, rng_offset);
-							#elif defined (RNG_ONEMKL_MCG59)
-							oneapi::mkl::rng::device::mcg59<16> rng_engine(rng_seed, rng_offset);
-							#endif
+							RNG_ONEMKL_TYPE rng_engine(rng_seed, rng_offset);
 
 							// Creating a continuous RNG distribution object
 							oneapi::mkl::rng::device::uniform<float> rng_continuous_distr;

--- a/dpcpp/kernel4.dp.cpp
+++ b/dpcpp/kernel4.dp.cpp
@@ -181,10 +181,10 @@ gpu_gen_and_eval_newpops_kernel(
 
 		item_ct1.barrier(SYCL_MEMORY_SPACE);
 		if ( (item_ct1.get_group(2) == 1) && (item_ct1.get_local_id(2) == 0) ) {
+			PRINTF("\nLocal work-item id: %d\n", item_ct1.get_local_id(2));
 			for (uint32_t j = 0; j < 10; j++) {
 				PRINTF("[%d]: gpu_randf=%2.4f, onemkl_rng=%2.4f\n", j, randnums[j], meme[j]);
 			}
-			PRINTF("\n", "");
 		}
 		item_ct1.barrier(SYCL_MEMORY_SPACE);
 

--- a/dpcpp/kernel4.dp.cpp
+++ b/dpcpp/kernel4.dp.cpp
@@ -64,7 +64,6 @@ gpu_gen_and_eval_newpops_kernel(
                                 float *sFloatAccumulator
 								,
 								oneapi::mkl::rng::device::philox4x32x10<64>* rng_engine,
-								oneapi::mkl::rng::device::uniform<uint32_t>* rng_discrete_distr,
 								oneapi::mkl::rng::device::uniform<float>* rng_continuous_distr
 								)
 // The GPU global function
@@ -478,9 +477,6 @@ void gpu_gen_and_eval_newpops(
 							uint64_t rng_offset = item_ct1.get_local_id(2) * threadsPerBlock;
 							oneapi::mkl::rng::device::philox4x32x10<64> rng_engine(rng_seed, rng_offset);
 
-							// Creating a discrete RNG distribution object
-							oneapi::mkl::rng::device::uniform<uint32_t> rng_discrete_distr;
-
 							// Creating a continuous RNG distribution object
 							oneapi::mkl::rng::device::uniform<float> rng_continuous_distr;
 
@@ -500,7 +496,6 @@ void gpu_gen_and_eval_newpops(
                                 sFloatAccumulator_acc_ct1.get_pointer()
 								,
 								&rng_engine,
-								&rng_discrete_distr,
 								&rng_continuous_distr
 								);
                     });

--- a/dpcpp/kernel4.dp.cpp
+++ b/dpcpp/kernel4.dp.cpp
@@ -63,7 +63,15 @@ gpu_gen_and_eval_newpops_kernel(
                                 sycl::float3 *calc_coords,
                                 float *sFloatAccumulator
 								,
+								#if defined(RNG_ONEMKL_MRG32K3A)
+								oneapi::mkl::rng::device::mrg32k3a<16>* rng_engine,
+								#elif defined (RNG_ONEMKL_PHILOX4X32X10)
 								oneapi::mkl::rng::device::philox4x32x10<16>* rng_engine,
+								#elif defined (RNG_ONEMKL_MCG31M1)
+								oneapi::mkl::rng::device::mcg31m1<16>* rng_engine,
+								#elif defined (RNG_ONEMKL_MCG59)
+								oneapi::mkl::rng::device::mcg59<16>* rng_engine,
+								#endif
 								oneapi::mkl::rng::device::uniform<float>* rng_continuous_distr
 								)
 // The GPU global function
@@ -475,7 +483,15 @@ void gpu_gen_and_eval_newpops(
 							// Creating an RNG engine object
 							uint64_t rng_seed = cData_ptr_ct1->pMem_prng_states[item_ct1.get_global_id(2)];
 							uint64_t rng_offset = item_ct1.get_local_id(2) * threadsPerBlock;
+							#if defined (RNG_ONEMKL_MRG32K3A)
+							oneapi::mkl::rng::device::mrg32k3a<16> rng_engine(rng_seed, rng_offset);
+							#elif defined (RNG_ONEMKL_PHILOX4X32X10)
 							oneapi::mkl::rng::device::philox4x32x10<16> rng_engine(rng_seed, rng_offset);
+							#elif defined (RNG_ONEMKL_MCG31M1)
+							oneapi::mkl::rng::device::mcg31m1<16> rng_engine(rng_seed, rng_offset);
+							#elif defined (RNG_ONEMKL_MCG59)
+							oneapi::mkl::rng::device::mcg59<16> rng_engine(rng_seed, rng_offset);
+							#endif
 
 							// Creating a continuous RNG distribution object
 							oneapi::mkl::rng::device::uniform<float> rng_continuous_distr;

--- a/dpcpp/kernel4.dp.cpp
+++ b/dpcpp/kernel4.dp.cpp
@@ -180,10 +180,11 @@ gpu_gen_and_eval_newpops_kernel(
                 }
 
 		item_ct1.barrier(SYCL_MEMORY_SPACE);
-		if ( (item_ct1.get_group(2) == 0) && item_ct1.get_local_id(2) == 0 ) {
+		if ( (item_ct1.get_group(2) == 1) && item_ct1.get_local_id(2) == 0 ) {
 			for (uint32_t j = 0; j < 10; j++) {
-				PRINTF("%2.4f %2.4f", randnums[j], meme[j]);
+				PRINTF("[%d]: gpu_randf=%2.4f \t onemkl::rng=%2.4f", j, randnums[j], meme[j]);
 			}
+			PRINTF("\n", "");
 		}
 		item_ct1.barrier(SYCL_MEMORY_SPACE);
 

--- a/dpcpp/kernel4.dp.cpp
+++ b/dpcpp/kernel4.dp.cpp
@@ -180,7 +180,7 @@ gpu_gen_and_eval_newpops_kernel(
                 }
 
 		item_ct1.barrier(SYCL_MEMORY_SPACE);
-		if ( (item_ct1.get_group(2) == 1) && item_ct1.get_local_id(2) == 0 ) {
+		if ( (item_ct1.get_group(2) == 1) && (item_ct1.get_local_id(2) == 0) ) {
 			for (uint32_t j = 0; j < 10; j++) {
 				PRINTF("[%d]: gpu_randf=%2.4f, onemkl_rng=%2.4f\n", j, randnums[j], meme[j]);
 			}

--- a/dpcpp/kernel4.dp.cpp
+++ b/dpcpp/kernel4.dp.cpp
@@ -29,7 +29,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 //#define DEBUG_ENERGY_KERNEL4
 
-#define DOCK_TRACE
+//#define DOCK_TRACE
 
 #ifdef DOCK_TRACE
 #ifdef __SYCL_DEVICE_ONLY__

--- a/dpcpp/kernel4.dp.cpp
+++ b/dpcpp/kernel4.dp.cpp
@@ -474,8 +474,11 @@ void gpu_gen_and_eval_newpops(
 							uint64_t rng_offset = item_ct1.get_local_id(2) * rng_VecSize;
 							oneapi::mkl::rng::device::philox4x32x10<rng_VecSize> rng_engine(rng_seed, rng_offset);
 
-							// Creating an RNG distribution object
-							oneapi::mkl::rng::device::uniform<> rng_distr;
+							// Creating a discrete RNG distribution object
+							oneapi::mkl::rng::device::uniform<uint32_t> rng_discrete_distr;
+
+							// Creating a continuous RNG distribution object
+							oneapi::mkl::rng::device::uniform<float> rng_continuous_distr;
 
                             gpu_gen_and_eval_newpops_kernel(
                                 pMem_conformations_current,

--- a/dpcpp/kernel4.dp.cpp
+++ b/dpcpp/kernel4.dp.cpp
@@ -354,19 +354,15 @@ gpu_gen_and_eval_newpops_kernel(
 				if (gene_counter < 3) {
                                         offspring_genotype[gene_counter] +=
                                             cData.dockpars.abs_max_dmov *
-                                            (2.0f * gpu_randf(
-                                                        cData.pMem_prng_states,
-                                                        item_ct1) -
-                                             1.0f);
+//                                            (2.0f * gpu_randf(cData.pMem_prng_states, item_ct1) - 1.0f);
+											(2.0f * oneapi::mkl::rng::device::generate_single(*rng_continuous_distr, *rng_engine) - 1.0f);
                                 }
 				// Orientation and torsion genes
 				else {
                                         offspring_genotype[gene_counter] +=
                                             cData.dockpars.abs_max_dang *
-                                            (2.0f * gpu_randf(
-                                                        cData.pMem_prng_states,
-                                                        item_ct1) -
-                                             1.0f);
+//                                            (2.0f * gpu_randf(cData.pMem_prng_states, item_ct1) - 1.0f);
+											(2.0f * oneapi::mkl::rng::device::generate_single(*rng_continuous_distr, *rng_engine) - 1.0f);
                                         map_angle(offspring_genotype[gene_counter]);
 				}
 

--- a/dpcpp/kernel4.dp.cpp
+++ b/dpcpp/kernel4.dp.cpp
@@ -63,7 +63,7 @@ gpu_gen_and_eval_newpops_kernel(
                                 sycl::float3 *calc_coords,
                                 float *sFloatAccumulator
 								,
-								oneapi::mkl::rng::device::philox4x32x10<64>* rng_engine,
+								oneapi::mkl::rng::device::philox4x32x10<16>* rng_engine,
 								oneapi::mkl::rng::device::uniform<float>* rng_continuous_distr
 								)
 // The GPU global function
@@ -475,7 +475,7 @@ void gpu_gen_and_eval_newpops(
 							// Creating an RNG engine object
 							uint64_t rng_seed = cData_ptr_ct1->pMem_prng_states[item_ct1.get_global_id(2)];
 							uint64_t rng_offset = item_ct1.get_local_id(2) * threadsPerBlock;
-							oneapi::mkl::rng::device::philox4x32x10<64> rng_engine(rng_seed, rng_offset);
+							oneapi::mkl::rng::device::philox4x32x10<16> rng_engine(rng_seed, rng_offset);
 
 							// Creating a continuous RNG distribution object
 							oneapi::mkl::rng::device::uniform<float> rng_continuous_distr;

--- a/dpcpp/kernel4.dp.cpp
+++ b/dpcpp/kernel4.dp.cpp
@@ -65,7 +65,7 @@ gpu_gen_and_eval_newpops_kernel(
 								#if !defined (RNG_ORIGINAL)
 								,
 								RNG_ONEMKL_ENGINE_TYPE* rng_engine,
-								oneapi::mkl::rng::device::uniform<float>* rng_continuous_distr
+								RNG_ONEMKL_DISTRIBUTION_TYPE* rng_continuous_distr
 								#endif
 								)
 // The GPU global function
@@ -493,7 +493,7 @@ void gpu_gen_and_eval_newpops(
 							RNG_ONEMKL_ENGINE_TYPE rng_engine(rng_seed, rng_offset);
 
 							// Creating a continuous RNG distribution object
-							oneapi::mkl::rng::device::uniform<float> rng_continuous_distr;
+							RNG_ONEMKL_DISTRIBUTION_TYPE rng_continuous_distr;
 							#endif
 
                             gpu_gen_and_eval_newpops_kernel(

--- a/dpcpp/kernel4.dp.cpp
+++ b/dpcpp/kernel4.dp.cpp
@@ -347,9 +347,8 @@ gpu_gen_and_eval_newpops_kernel(
                 {
 			// Notice: dockpars_mutation_rate was scaled down to [0,1] in host
 			// to reduce number of operations in device
-                        if (/*100.0f**/ gpu_randf(cData.pMem_prng_states,
-                                                  item_ct1) <
-                            cData.dockpars.mutation_rate)
+//                        if (/*100.0f**/ gpu_randf(cData.pMem_prng_states, item_ct1) < cData.dockpars.mutation_rate)
+						if (oneapi::mkl::rng::device::generate_single(*rng_continuous_distr, *rng_engine) < cData.dockpars.mutation_rate)
                         {
 				// Translation genes
 				if (gene_counter < 3) {

--- a/dpcpp/kernel4.dp.cpp
+++ b/dpcpp/kernel4.dp.cpp
@@ -474,8 +474,8 @@ void gpu_gen_and_eval_newpops(
                     [[intel::reqd_sub_group_size(32)]] {
 
 							// Creating an RNG engine object
-							uint64_t rng_seed = cData_ptr_ct1->pMem_prng_states[0];
-							uint64_t rng_offset = item_ct1.get_local_id(2) * 64;;
+							uint64_t rng_seed = cData_ptr_ct1->pMem_prng_states[item_ct1.get_global_id(2)];
+							uint64_t rng_offset = item_ct1.get_local_id(2) * threadsPerBlock;
 							oneapi::mkl::rng::device::philox4x32x10<64> rng_engine(rng_seed, rng_offset);
 
 							// Creating a discrete RNG distribution object

--- a/dpcpp/kernel4.dp.cpp
+++ b/dpcpp/kernel4.dp.cpp
@@ -182,7 +182,7 @@ gpu_gen_and_eval_newpops_kernel(
 		item_ct1.barrier(SYCL_MEMORY_SPACE);
 		if ( (item_ct1.get_group(2) == 1) && item_ct1.get_local_id(2) == 0 ) {
 			for (uint32_t j = 0; j < 10; j++) {
-				PRINTF("[%d]: gpu_randf=%2.4f	|	onemkl::rng=%2.4f\n", j, randnums[j], meme[j]);
+				PRINTF("[%d]: gpu_randf=%2.4f, onemkl_rng=%2.4f\n", j, randnums[j], meme[j]);
 			}
 			PRINTF("\n", "");
 		}

--- a/dpcpp/kernel_ad.dp.cpp
+++ b/dpcpp/kernel_ad.dp.cpp
@@ -78,7 +78,7 @@ gpu_gradient_minAD_kernel(
                           int *cons_fail
 						#if !defined (RNG_ORIGINAL)
 						,
-						RNG_ONEMKL_TYPE* rng_engine,
+						RNG_ONEMKL_ENGINE_TYPE* rng_engine,
 						oneapi::mkl::rng::device::uniform<float>* rng_continuous_distr
 						#endif
 )
@@ -508,7 +508,7 @@ void gpu_gradient_minAD(
 							// Creating an RNG engine object
 							uint64_t rng_seed = cData_ptr_ct1->pMem_prng_states[item_ct1.get_global_id(2)];
 							uint64_t rng_offset = item_ct1.get_local_id(2) * threads;
-							RNG_ONEMKL_TYPE rng_engine(rng_seed, rng_offset);
+							RNG_ONEMKL_ENGINE_TYPE rng_engine(rng_seed, rng_offset);
 
 							// Creating a continuous RNG distribution object
 							oneapi::mkl::rng::device::uniform<float> rng_continuous_distr;

--- a/dpcpp/kernel_ad.dp.cpp
+++ b/dpcpp/kernel_ad.dp.cpp
@@ -79,7 +79,7 @@ gpu_gradient_minAD_kernel(
 						#if !defined (RNG_ORIGINAL)
 						,
 						RNG_ONEMKL_ENGINE_TYPE* rng_engine,
-						oneapi::mkl::rng::device::uniform<float>* rng_continuous_distr
+						RNG_ONEMKL_DISTRIBUTION_TYPE* rng_continuous_distr
 						#endif
 )
 // The GPU global function performs gradient-based minimization on (some) entities of conformations_next.
@@ -511,7 +511,7 @@ void gpu_gradient_minAD(
 							RNG_ONEMKL_ENGINE_TYPE rng_engine(rng_seed, rng_offset);
 
 							// Creating a continuous RNG distribution object
-							oneapi::mkl::rng::device::uniform<float> rng_continuous_distr;
+							RNG_ONEMKL_DISTRIBUTION_TYPE rng_continuous_distr;
 							#endif
 
                             gpu_gradient_minAD_kernel(

--- a/dpcpp/kernel_ad.dp.cpp
+++ b/dpcpp/kernel_ad.dp.cpp
@@ -77,7 +77,7 @@ gpu_gradient_minAD_kernel(
                           int *cons_succ,
                           int *cons_fail
 						,
-						oneapi::mkl::rng::device::philox4x32x10<64>* rng_engine,
+						oneapi::mkl::rng::device::philox4x32x10<16>* rng_engine,
 						oneapi::mkl::rng::device::uniform<float>* rng_continuous_distr
 )
 // The GPU global function performs gradient-based minimization on (some) entities of conformations_next.
@@ -502,7 +502,7 @@ void gpu_gradient_minAD(
 							// Creating an RNG engine object
 							uint64_t rng_seed = cData_ptr_ct1->pMem_prng_states[item_ct1.get_global_id(2)];
 							uint64_t rng_offset = item_ct1.get_local_id(2) * threads;
-							oneapi::mkl::rng::device::philox4x32x10<64> rng_engine(rng_seed, rng_offset);
+							oneapi::mkl::rng::device::philox4x32x10<16> rng_engine(rng_seed, rng_offset);
 
 							// Creating a continuous RNG distribution object
 							oneapi::mkl::rng::device::uniform<float> rng_continuous_distr;

--- a/dpcpp/kernel_adam.dp.cpp
+++ b/dpcpp/kernel_adam.dp.cpp
@@ -67,7 +67,7 @@ gpu_gradient_minAdam_kernel(
                             float *best_energy,
                             float *sFloatAccumulator
 						,
-						oneapi::mkl::rng::device::philox4x32x10<64>* rng_engine,
+						oneapi::mkl::rng::device::philox4x32x10<16>* rng_engine,
 						oneapi::mkl::rng::device::uniform<float>* rng_continuous_distr
 )
 // The GPU global function performs gradient-based minimization on (some) entities of conformations_next.
@@ -496,7 +496,7 @@ void gpu_gradient_minAdam(
 							// Creating an RNG engine object
 							uint64_t rng_seed = cData_ptr_ct1->pMem_prng_states[item_ct1.get_global_id(2)];
 							uint64_t rng_offset = item_ct1.get_local_id(2) * threads;
-							oneapi::mkl::rng::device::philox4x32x10<64> rng_engine(rng_seed, rng_offset);
+							oneapi::mkl::rng::device::philox4x32x10<16> rng_engine(rng_seed, rng_offset);
 
 							// Creating a continuous RNG distribution object
 							oneapi::mkl::rng::device::uniform<float> rng_continuous_distr;

--- a/dpcpp/kernel_adam.dp.cpp
+++ b/dpcpp/kernel_adam.dp.cpp
@@ -68,7 +68,7 @@ gpu_gradient_minAdam_kernel(
                             float *sFloatAccumulator
 						#if !defined (RNG_ORIGINAL)
 						,
-						RNG_ONEMKL_TYPE* rng_engine,
+						RNG_ONEMKL_ENGINE_TYPE* rng_engine,
 						oneapi::mkl::rng::device::uniform<float>* rng_continuous_distr
 						#endif
 )
@@ -502,7 +502,7 @@ void gpu_gradient_minAdam(
 							// Creating an RNG engine object
 							uint64_t rng_seed = cData_ptr_ct1->pMem_prng_states[item_ct1.get_global_id(2)];
 							uint64_t rng_offset = item_ct1.get_local_id(2) * threads;
-							RNG_ONEMKL_TYPE rng_engine(rng_seed, rng_offset);
+							RNG_ONEMKL_ENGINE_TYPE rng_engine(rng_seed, rng_offset);
 
 							// Creating a continuous RNG distribution object
 							oneapi::mkl::rng::device::uniform<float> rng_continuous_distr;

--- a/dpcpp/kernel_adam.dp.cpp
+++ b/dpcpp/kernel_adam.dp.cpp
@@ -69,7 +69,7 @@ gpu_gradient_minAdam_kernel(
 						#if !defined (RNG_ORIGINAL)
 						,
 						RNG_ONEMKL_ENGINE_TYPE* rng_engine,
-						oneapi::mkl::rng::device::uniform<float>* rng_continuous_distr
+						RNG_ONEMKL_DISTRIBUTION_TYPE* rng_continuous_distr
 						#endif
 )
 // The GPU global function performs gradient-based minimization on (some) entities of conformations_next.
@@ -505,7 +505,7 @@ void gpu_gradient_minAdam(
 							RNG_ONEMKL_ENGINE_TYPE rng_engine(rng_seed, rng_offset);
 
 							// Creating a continuous RNG distribution object
-							oneapi::mkl::rng::device::uniform<float> rng_continuous_distr;
+							RNG_ONEMKL_DISTRIBUTION_TYPE rng_continuous_distr;
 							#endif
 
                             gpu_gradient_minAdam_kernel(

--- a/dpcpp/kernel_adam.dp.cpp
+++ b/dpcpp/kernel_adam.dp.cpp
@@ -66,9 +66,11 @@ gpu_gradient_minAdam_kernel(
                             int *entity_id,
                             float *best_energy,
                             float *sFloatAccumulator
+						#if !defined (RNG_ORIGINAL)
 						,
-						oneapi::mkl::rng::device::philox4x32x10<16>* rng_engine,
+						RNG_ONEMKL_TYPE* rng_engine,
 						oneapi::mkl::rng::device::uniform<float>* rng_continuous_distr
+						#endif
 )
 // The GPU global function performs gradient-based minimization on (some) entities of conformations_next.
 // The number of OpenCL compute units (CU) which should be started equals to num_of_minEntities*num_of_runs.
@@ -128,8 +130,11 @@ gpu_gradient_minAdam_kernel(
                         // If entity 0 is not selected according to LS-rate,
 			// choosing another entity
                         if (100.0f *
-//                                gpu_randf(cData.pMem_prng_states, item_ct1) >
+								#if defined (RNG_ORIGINAL)
+                                gpu_randf(cData.pMem_prng_states, item_ct1) >
+								#else
 								oneapi::mkl::rng::device::generate_single(*rng_continuous_distr, *rng_engine) >
+								#endif
                             cData.dockpars.lsearch_rate) {
                                 *entity_id =
                                     cData.dockpars
@@ -493,13 +498,15 @@ void gpu_gradient_minAdam(
                                       sycl::range<3>(1, 1, threads)),
                     [=](sycl::nd_item<3> item_ct1) {
 
+							#if !defined (RNG_ORIGINAL)
 							// Creating an RNG engine object
 							uint64_t rng_seed = cData_ptr_ct1->pMem_prng_states[item_ct1.get_global_id(2)];
 							uint64_t rng_offset = item_ct1.get_local_id(2) * threads;
-							oneapi::mkl::rng::device::philox4x32x10<16> rng_engine(rng_seed, rng_offset);
+							RNG_ONEMKL_TYPE rng_engine(rng_seed, rng_offset);
 
 							// Creating a continuous RNG distribution object
 							oneapi::mkl::rng::device::uniform<float> rng_continuous_distr;
+							#endif
 
                             gpu_gradient_minAdam_kernel(
                                 pMem_conformations_next, pMem_energies_next,
@@ -507,9 +514,11 @@ void gpu_gradient_minAdam(
                                 *cData_ptr_ct1, entity_id_acc_ct1.get_pointer(),
                                 best_energy_acc_ct1.get_pointer(),
                                 sFloatAccumulator_acc_ct1.get_pointer()
+								#if !defined (RNG_ORIGINAL)
 								,
 								&rng_engine,
 								&rng_continuous_distr
+								#endif
 								);
                     });
         });

--- a/dpcpp/kernels.dp.cpp
+++ b/dpcpp/kernels.dp.cpp
@@ -38,6 +38,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 //#define RNG_ONEMKL_MCG31M1
 #define RNG_ONEMKL_MCG59
 
+// Throwing error if two oneMKL RNG engine types is selected
 #if defined (RNG_ONEMKL_MRG32K3A) && (defined (RNG_ONEMKL_PHILOX4X32X10) || defined (RNG_ONEMKL_MCG31M1) || defined (RNG_ONEMKL_MCG59))
 	#error "RNG_ONEMKL_MRG32K3A is defined. Do not define additional ONEMKL RNG engines!"
 #elif defined (RNG_ONEMKL_PHILOX4X32X10) && (defined (RNG_ONEMKL_MRG32K3A) || defined (RNG_ONEMKL_MCG31M1) || defined (RNG_ONEMKL_MCG59))
@@ -48,6 +49,17 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 	#error "RNG_ONEMKL_MCG59 is defined. Do not define additional ONEMKL RNG engines!"
 #elif !defined (RNG_ONEMKL_MRG32K3A) && !defined (RNG_ONEMKL_PHILOX4X32X10) && !defined (RNG_ONEMKL_MCG31M1) && !defined (RNG_ONEMKL_MCG59)
 	#error "Define either RNG_ONEMKL_MRG32K3A or RNG_ONEMKL_PHILOX4X32X10 or RNG_ONEMKL_MCG31M1 or RNG_ONEMKL_MCG59"
+#endif
+
+// Defining data type for selected engine type
+#if defined (RNG_ONEMKL_MRG32K3A)
+	#define RNG_ONEMKL_TYPE	oneapi::mkl::rng::device::mrg32k3a<16>
+#elif defined (RNG_ONEMKL_PHILOX4X32X10)
+	#define RNG_ONEMKL_TYPE	oneapi::mkl::rng::device::philox4x32x10<16>
+#elif defined (RNG_ONEMKL_MCG31M1)
+	#define RNG_ONEMKL_TYPE oneapi::mkl::rng::device::mcg31m1<16>
+#elif defined (RNG_ONEMKL_MCG59)
+	#define RNG_ONEMKL_TYPE oneapi::mkl::rng::device::mcg59<16>
 #endif
 
 inline uint64_t llitoulli(int64_t l)

--- a/dpcpp/kernels.dp.cpp
+++ b/dpcpp/kernels.dp.cpp
@@ -52,7 +52,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 	#define RNG_ORIGINAL
 #endif
 
-// Defining data type for selected engine type
+// Defining data type for selected oneMKL RNG engine type
 #if defined (RNG_ONEMKL_MRG32K3A)
 	#define RNG_ONEMKL_ENGINE_TYPE	oneapi::mkl::rng::device::mrg32k3a<16>
 #elif defined (RNG_ONEMKL_PHILOX4X32X10)
@@ -61,6 +61,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 	#define RNG_ONEMKL_ENGINE_TYPE oneapi::mkl::rng::device::mcg31m1<16>
 #elif defined (RNG_ONEMKL_MCG59)
 	#define RNG_ONEMKL_ENGINE_TYPE oneapi::mkl::rng::device::mcg59<16>
+#endif
+
+// Defining data type for oneMKL RNG distribution type
+#if !defined (RNG_ORIGINAL)
+	#define RNG_ONEMKL_DISTRIBUTION_TYPE oneapi::mkl::rng::device::uniform<float>
 #endif
 
 inline uint64_t llitoulli(int64_t l)

--- a/dpcpp/kernels.dp.cpp
+++ b/dpcpp/kernels.dp.cpp
@@ -39,6 +39,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 //#define RNG_ONEMKL_MCG59
 
 // Throwing error if two oneMKL RNG engine types is selected
+// If no oneMKL RNG is selected, then using original adhoc/manual RNG
 #if defined (RNG_ONEMKL_MRG32K3A) && (defined (RNG_ONEMKL_PHILOX4X32X10) || defined (RNG_ONEMKL_MCG31M1) || defined (RNG_ONEMKL_MCG59))
 	#error "RNG_ONEMKL_MRG32K3A is defined. Do not define additional ONEMKL RNG engines!"
 #elif defined (RNG_ONEMKL_PHILOX4X32X10) && (defined (RNG_ONEMKL_MRG32K3A) || defined (RNG_ONEMKL_MCG31M1) || defined (RNG_ONEMKL_MCG59))
@@ -48,20 +49,18 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #elif defined (RNG_ONEMKL_MCG59) && (defined (RNG_ONEMKL_MRG32K3A) || defined (RNG_ONEMKL_PHILOX4X32X10) || defined (RNG_ONEMKL_MCG31M1))
 	#error "RNG_ONEMKL_MCG59 is defined. Do not define additional ONEMKL RNG engines!"
 #elif !defined (RNG_ONEMKL_MRG32K3A) && !defined (RNG_ONEMKL_PHILOX4X32X10) && !defined (RNG_ONEMKL_MCG31M1) && !defined (RNG_ONEMKL_MCG59)
-//	#error "Define either RNG_ONEMKL_MRG32K3A or RNG_ONEMKL_PHILOX4X32X10 or RNG_ONEMKL_MCG31M1 or RNG_ONEMKL_MCG59"
+	#define RNG_ORIGINAL
 #endif
 
 // Defining data type for selected engine type
 #if defined (RNG_ONEMKL_MRG32K3A)
-	#define RNG_ONEMKL_TYPE	oneapi::mkl::rng::device::mrg32k3a<16>
+	#define RNG_ONEMKL_ENGINE_TYPE	oneapi::mkl::rng::device::mrg32k3a<16>
 #elif defined (RNG_ONEMKL_PHILOX4X32X10)
-	#define RNG_ONEMKL_TYPE	oneapi::mkl::rng::device::philox4x32x10<16>
+	#define RNG_ONEMKL_ENGINE_TYPE	oneapi::mkl::rng::device::philox4x32x10<16>
 #elif defined (RNG_ONEMKL_MCG31M1)
-	#define RNG_ONEMKL_TYPE oneapi::mkl::rng::device::mcg31m1<16>
+	#define RNG_ONEMKL_ENGINE_TYPE oneapi::mkl::rng::device::mcg31m1<16>
 #elif defined (RNG_ONEMKL_MCG59)
-	#define RNG_ONEMKL_TYPE oneapi::mkl::rng::device::mcg59<16>
-#else
-	#define RNG_ORIGINAL
+	#define RNG_ONEMKL_ENGINE_TYPE oneapi::mkl::rng::device::mcg59<16>
 #endif
 
 inline uint64_t llitoulli(int64_t l)

--- a/dpcpp/kernels.dp.cpp
+++ b/dpcpp/kernels.dp.cpp
@@ -36,7 +36,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 //#define RNG_ONEMKL_MRG32K3A
 //#define RNG_ONEMKL_PHILOX4X32X10
 //#define RNG_ONEMKL_MCG31M1
-#define RNG_ONEMKL_MCG59
+//#define RNG_ONEMKL_MCG59
 
 // Throwing error if two oneMKL RNG engine types is selected
 #if defined (RNG_ONEMKL_MRG32K3A) && (defined (RNG_ONEMKL_PHILOX4X32X10) || defined (RNG_ONEMKL_MCG31M1) || defined (RNG_ONEMKL_MCG59))
@@ -48,7 +48,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #elif defined (RNG_ONEMKL_MCG59) && (defined (RNG_ONEMKL_MRG32K3A) || defined (RNG_ONEMKL_PHILOX4X32X10) || defined (RNG_ONEMKL_MCG31M1))
 	#error "RNG_ONEMKL_MCG59 is defined. Do not define additional ONEMKL RNG engines!"
 #elif !defined (RNG_ONEMKL_MRG32K3A) && !defined (RNG_ONEMKL_PHILOX4X32X10) && !defined (RNG_ONEMKL_MCG31M1) && !defined (RNG_ONEMKL_MCG59)
-	#error "Define either RNG_ONEMKL_MRG32K3A or RNG_ONEMKL_PHILOX4X32X10 or RNG_ONEMKL_MCG31M1 or RNG_ONEMKL_MCG59"
+//	#error "Define either RNG_ONEMKL_MRG32K3A or RNG_ONEMKL_PHILOX4X32X10 or RNG_ONEMKL_MCG31M1 or RNG_ONEMKL_MCG59"
 #endif
 
 // Defining data type for selected engine type
@@ -60,6 +60,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 	#define RNG_ONEMKL_TYPE oneapi::mkl::rng::device::mcg31m1<16>
 #elif defined (RNG_ONEMKL_MCG59)
 	#define RNG_ONEMKL_TYPE oneapi::mkl::rng::device::mcg59<16>
+#else
+	#define RNG_ORIGINAL
 #endif
 
 inline uint64_t llitoulli(int64_t l)

--- a/dpcpp/kernels.dp.cpp
+++ b/dpcpp/kernels.dp.cpp
@@ -33,13 +33,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include "dpcpp_migration.h"
 #include "oneapi/mkl/rng/device.hpp"
 
+// Throwing error if two oneMKL RNG engine types is selected
+// If no oneMKL RNG is selected, then using original adhoc/manual RNG
+
 //#define RNG_ONEMKL_MRG32K3A
 //#define RNG_ONEMKL_PHILOX4X32X10
 //#define RNG_ONEMKL_MCG31M1
 //#define RNG_ONEMKL_MCG59
 
-// Throwing error if two oneMKL RNG engine types is selected
-// If no oneMKL RNG is selected, then using original adhoc/manual RNG
 #if defined (RNG_ONEMKL_MRG32K3A) && (defined (RNG_ONEMKL_PHILOX4X32X10) || defined (RNG_ONEMKL_MCG31M1) || defined (RNG_ONEMKL_MCG59))
 	#error "RNG_ONEMKL_MRG32K3A is defined. Do not define additional ONEMKL RNG engines!"
 #elif defined (RNG_ONEMKL_PHILOX4X32X10) && (defined (RNG_ONEMKL_MRG32K3A) || defined (RNG_ONEMKL_MCG31M1) || defined (RNG_ONEMKL_MCG59))

--- a/dpcpp/kernels.dp.cpp
+++ b/dpcpp/kernels.dp.cpp
@@ -33,6 +33,23 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include "dpcpp_migration.h"
 #include "oneapi/mkl/rng/device.hpp"
 
+//#define RNG_ONEMKL_MRG32K3A
+//#define RNG_ONEMKL_PHILOX4X32X10
+//#define RNG_ONEMKL_MCG31M1
+#define RNG_ONEMKL_MCG59
+
+#if defined (RNG_ONEMKL_MRG32K3A) && (defined (RNG_ONEMKL_PHILOX4X32X10) || defined (RNG_ONEMKL_MCG31M1) || defined (RNG_ONEMKL_MCG59))
+	#error "RNG_ONEMKL_MRG32K3A is defined. Do not define additional ONEMKL RNG engines!"
+#elif defined (RNG_ONEMKL_PHILOX4X32X10) && (defined (RNG_ONEMKL_MRG32K3A) || defined (RNG_ONEMKL_MCG31M1) || defined (RNG_ONEMKL_MCG59))
+	#error "RNG_ONEMKL_PHILOX4X32X10 is defined. Do not define additional ONEMKL RNG engines!"
+#elif defined (RNG_ONEMKL_MCG31M1) && (defined (RNG_ONEMKL_MRG32K3A) || defined (RNG_ONEMKL_PHILOX4X32X10) || defined (RNG_ONEMKL_MCG59))
+	#error "RNG_ONEMKL_MCG31M1 is defined. Do not define additional ONEMKL RNG engines!"
+#elif defined (RNG_ONEMKL_MCG59) && (defined (RNG_ONEMKL_MRG32K3A) || defined (RNG_ONEMKL_PHILOX4X32X10) || defined (RNG_ONEMKL_MCG31M1))
+	#error "RNG_ONEMKL_MCG59 is defined. Do not define additional ONEMKL RNG engines!"
+#elif !defined (RNG_ONEMKL_MRG32K3A) && !defined (RNG_ONEMKL_PHILOX4X32X10) && !defined (RNG_ONEMKL_MCG31M1) && !defined (RNG_ONEMKL_MCG59)
+	#error "Define either RNG_ONEMKL_MRG32K3A or RNG_ONEMKL_PHILOX4X32X10 or RNG_ONEMKL_MCG31M1 or RNG_ONEMKL_MCG59"
+#endif
+
 inline uint64_t llitoulli(int64_t l)
 {
 	uint64_t u;

--- a/dpcpp/kernels.dp.cpp
+++ b/dpcpp/kernels.dp.cpp
@@ -31,6 +31,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include "calcenergy.h"
 #include "GpuData.h"
 #include "dpcpp_migration.h"
+#include "oneapi/mkl/rng/device.hpp"
 
 inline uint64_t llitoulli(int64_t l)
 {


### PR DESCRIPTION
# About

This PR proposes using oneMKL RNG generators as alternatives RNGs in device code. So far only the `generate_single()` is employed.

- By default, the original RNGs are used.
- To select an oneMKL RNG engine, uncomment the corresponding line in `dpcpp/kernels.dp.cpp`:

```cpp
//#define RNG_ONEMKL_MRG32K3A
//#define RNG_ONEMKL_PHILOX4X32X10
//#define RNG_ONEMKL_MCG31M1
//#define RNG_ONEMKL_MCG59
```

## Evaluation on DevCloud Gen9 GPU: _docking time (s)_

###  Early-termination enabled

`make DEVICE=XeGPU TEST=sw/ad test`

|                             | SW        |  AD       |
| -------------------|--------- | ---------|
|  Original              |  58.99   |  45.98    |
|  MRG32K3A        |   65.51  |  57.89    |
| PHILOX4X32X10 |   60.58  |  48.15    |
| MCG31M1          |   60.09  |  46.62    |
| MCG59               |   56.63  |  47.91    |

### Early-termination disabled

- ` make DEVICE=XeGPU`
- `./bin/autodock_xegpu_64wi -ffile ./input/3ce3/derived/3ce3_protein.maps.fld -lfile ./input/3ce3/derived/3ce3_ligand.pdbqt -nrun 20 -ngen 27000 -psize 150 -resnam test -gfpop 0 -A 0 -H 0 -lsmet sw/ad`

|                             | SW        |  AD       |
| -------------------|--------- | ---------|
|  Original              |  43.07   |  95.97    |
|  MRG32K3A        |  62.39   |  112.61  |
| PHILOX4X32X10 |  44.21   |  96.93    |
| MCG31M1          |  43.29   |  96.74    |
| MCG59               |  43.38   |  96.59    |



