### PR TITLE
Reducing register pressure via additional compiler option

### DIFF
--- a/Makefile.dpcpp
+++ b/Makefile.dpcpp
@@ -28,7 +28,9 @@ else ifeq ($(DEVICE), GPU)
 	ifeq ($(PLATFORM), NvGPU)
 		DPCPP=clang++
 		CPP=clang++
-		IFLAGS=-fsycl -fsycl-targets=nvptx64-nvidia-cuda -fgpu-inline-threshold=100000 -Xsycl-target-backend --cuda-gpu-arch=sm_80 -Xcuda-ptxas --verbose --cuda-path=${CUDA_TOOLKIT_ROOT_DIR}
+		IFLAGS=-fsycl -fsycl-targets=nvptx64-nvidia-cuda -fgpu-inline-threshold=100000 -Xsycl-target-backend --cuda-gpu-arch=sm_80 \
+		-Xcuda-ptxas --verbose -Xcuda-ptxas --maxrregcount=64 \
+		--cuda-path=${CUDA_TOOLKIT_ROOT_DIR}
 	endif
 endif
 


### PR DESCRIPTION
This PR speeds up execution of the SYCL version in around 10% (Solis-Wets) and 20% (ADADELTA).

In the CUDA version, the control of register pressure is already done via the `__launch_bounds__` qualifier.