### PR TITLE
Replacing pow() with native counterpart

### DIFF
--- a/common/defines.h
+++ b/common/defines.h
@@ -140,6 +140,7 @@ enum {C=0,N=1,O=2,H=3,XX=4,P=5,S=6};  // see "bond_index" in the "AD4.1_bound.da
 	#define SYCL_COS(x) sycl::native::cos(x)
 	#define SYCL_DIVIDE(x,y) sycl::native::divide(x,y)
 	#define SYCL_RECIP(x) sycl::native::recip(x)
+	#define SYCL_POWN(x,y) sycl::native::powr(x, (float)(y)) // Conditions: x>=0. Additional: y (originally integer) is transformed into float
 #else
 	#define SYCL_SQRT(x) sycl::sqrt(x)
 	#define SYCL_RSQRT(x) (1.0f/SYCL_SQRT(x))
@@ -147,6 +148,7 @@ enum {C=0,N=1,O=2,H=3,XX=4,P=5,S=6};  // see "bond_index" in the "AD4.1_bound.da
 	#define SYCL_COS(x) sycl::cos(x)
 	#define SYCL_DIVIDE(x,y) (x/y)
 	#define SYCL_RECIP(x) (1.0f/x)
+	#define SYCL_POWN(x,y) sycl::pow<float>(x,y)
 #endif
 
 // Enables switching between local and global memory for barriers in device code

--- a/dpcpp/calcMergeEneGra.dp.cpp
+++ b/dpcpp/calcMergeEneGra.dp.cpp
@@ -549,8 +549,8 @@ SYCL_EXTERNAL void gpu_calc_energrad(float *genotype, float &global_energy,
                                                    opt_dist_delta);
                         } else smoothed_distance = opt_distance;
 			// Calculating van der Waals / hydrogen bond term
-                        float rmn = sycl::pown(smoothed_distance, m - n);
-                        float rm = sycl::pown(smoothed_distance, -m);
+                        float rmn = SYCL_POWN(smoothed_distance, (m - n));
+                        float rm = SYCL_POWN(smoothed_distance, (-m));
                         energy += (cData.pKerconst_intra->VWpars_AC_const[idx]
 			           -rmn*cData.pKerconst_intra->VWpars_BD_const[idx])*rm;
 

--- a/dpcpp/calcenergy.dp.cpp
+++ b/dpcpp/calcenergy.dp.cpp
@@ -450,9 +450,9 @@ SYCL_EXTERNAL void gpu_calc_energy(float *pGenotype, float &energy, int &run_id,
 			// Calculating van der Waals / hydrogen bond term
                         energy +=
                             (cData.pKerconst_intra->VWpars_AC_const[idx] -
-                             sycl::pown(smoothed_distance, m - n) *
+                             SYCL_POWN(smoothed_distance, (m - n)) *
                                  cData.pKerconst_intra->VWpars_BD_const[idx]) *
-                            sycl::pown(smoothed_distance, -m);
+                            SYCL_POWN(smoothed_distance, (-m));
 #if defined (DEBUG_ENERGY_KERNEL)
 			intraE += (cData.pKerconst_intra->VWpars_AC_const[idx]
 			           -__powf(smoothed_distance,m-n)*cData.pKerconst_intra->VWpars_BD_const[idx])

--- a/dpcpp/kernel_adam.dp.cpp
+++ b/dpcpp/kernel_adam.dp.cpp
@@ -304,11 +304,9 @@ gpu_gradient_minAdam_kernel(
 		}
 #endif
                 float beta1p =
-                    1.0f - sycl::pow<float>(cData.dockpars.adam_beta1,
-                                             1.0f + iteration_cnt);
+                    1.0f - SYCL_POWN(cData.dockpars.adam_beta1, (1.0f + iteration_cnt));
                 float beta2p =
-                    1.0f - sycl::pow<float>(cData.dockpars.adam_beta2,
-                                             1.0f + iteration_cnt);
+                    1.0f - SYCL_POWN(cData.dockpars.adam_beta2, (1.0f + iteration_cnt));
 
                 for (int i = item_ct1.get_local_id(2);
                      i < cData.dockpars.num_of_genes;


### PR DESCRIPTION
This PR puts both CUDA and SYCL versions on par, performance-wise. Tested on A100 GPU.