### PR TITLE
Adapting SYCL subgroup size according to the WGsize

### DIFF
--- a/common/defines.h
+++ b/common/defines.h
@@ -27,30 +27,46 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #ifndef DEFINES_H_
 #define DEFINES_H_
 
+/*
+	Using clinfo output to define reasonable SYCL subgroup sizes:
+	Sub-group sizes (Intel) 4, 8, 16, 32, 64
+*/
 #if defined (N1WI)
 	#define NUM_OF_THREADS_PER_BLOCK 1
+	// Min. subgroup size = 4. Here it doesn't make sense to define it
 #elif defined (N2WI)
 	#define NUM_OF_THREADS_PER_BLOCK 2
+	// Min. subgroup size = 4. Here it doesn't make sense to define it
 #elif defined (N4WI)
 	#define NUM_OF_THREADS_PER_BLOCK 4
+	#define NUM_OF_THREADS_PER_SYCL_SUBGROUP 4
 #elif defined (N8WI)
 	#define NUM_OF_THREADS_PER_BLOCK 8
+	#define NUM_OF_THREADS_PER_SYCL_SUBGROUP (NUM_OF_THREADS_PER_BLOCK/2)
 #elif defined (N16WI)
 	#define NUM_OF_THREADS_PER_BLOCK 16
+	#define NUM_OF_THREADS_PER_SYCL_SUBGROUP (NUM_OF_THREADS_PER_BLOCK/2)
 #elif defined (N32WI)
 	#define NUM_OF_THREADS_PER_BLOCK 32
+	#define NUM_OF_THREADS_PER_SYCL_SUBGROUP (NUM_OF_THREADS_PER_BLOCK/2)
 #elif defined (N64WI)
 	#define NUM_OF_THREADS_PER_BLOCK 64
+	#define NUM_OF_THREADS_PER_SYCL_SUBGROUP (NUM_OF_THREADS_PER_BLOCK/2)
 #elif defined (N128WI)
 	#define NUM_OF_THREADS_PER_BLOCK 128
+	#define NUM_OF_THREADS_PER_SYCL_SUBGROUP (NUM_OF_THREADS_PER_BLOCK/2)
 #elif defined (N256WI)
 	#define NUM_OF_THREADS_PER_BLOCK 256
+	#define NUM_OF_THREADS_PER_SYCL_SUBGROUP 4
 #elif defined (N512WI)
 	#define NUM_OF_THREADS_PER_BLOCK 512
+	#define NUM_OF_THREADS_PER_SYCL_SUBGROUP 4
 #elif defined (N1024WI)
 	#define NUM_OF_THREADS_PER_BLOCK 1024
+	#define NUM_OF_THREADS_PER_SYCL_SUBGROUP 4
 #else
 	#define NUM_OF_THREADS_PER_BLOCK 16
+	#define NUM_OF_THREADS_PER_SYCL_SUBGROUP 4
 #endif
 
 typedef enum

--- a/dpcpp/kernel4.dp.cpp
+++ b/dpcpp/kernel4.dp.cpp
@@ -444,7 +444,7 @@ void gpu_gen_and_eval_newpops(
                                           sycl::range<3>(1, 1, threadsPerBlock),
                                       sycl::range<3>(1, 1, threadsPerBlock)),
                     [=](sycl::nd_item<3> item_ct1) 
-                    [[intel::reqd_sub_group_size(32)]] {
+                    [[intel::reqd_sub_group_size(NUM_OF_THREADS_PER_SYCL_SUBGROUP)]] {
                             gpu_gen_and_eval_newpops_kernel(
                                 pMem_conformations_current,
                                 pMem_energies_current, pMem_conformations_next,

--- a/host/src/performdocking.cpp.dpcpp
+++ b/host/src/performdocking.cpp.dpcpp
@@ -796,6 +796,9 @@ int docking_with_gpu(const Gridinfo *mygrid, Dockpars *mypars,
 	blocksPerGridForEachEntity = mypars->pop_size * mypars->num_of_runs;
 	blocksPerGridForEachRun = mypars->num_of_runs;
 
+	int SYCL_subgroup_size = NUM_OF_THREADS_PER_SYCL_SUBGROUP;
+	printf("\n    SYCL Work-group Size: %u\n    SYCL Subgroup Size: %u\n\n", threadsPerBlock, NUM_OF_THREADS_PER_SYCL_SUBGROUP);fflush(stdout);
+
 	// allocating CPU memory for initial populations
 	size_populations = mypars->num_of_runs * mypars->pop_size * GENOTYPE_LENGTH_IN_GLOBMEM*sizeof(float);
 	sim_state.cpu_populations.resize(size_populations);


### PR DESCRIPTION
Current SYCL subgroup sizes are hardcoded (= 32). 

However, programs compiled with `NUWI=16` and `CONFIG=LDEBUG` end up segfaulting.

This PR aims to set reasonable SYCL subgroup sizes, i.e., values that are:
1) smaller than the WGsize
2) typically supported on CPUs (e.g., 4, 8, 16, 32, 64)

In addition, the PR enables information on the chosen WGsize and subgroup sizes:

```
...
Running Job #1

    SYCL Work-group Size: 16
    SYCL Subgroup Size: 8

   Using heuristics: (capped) number of evaluations set to 682873
   ...
```

Example commands:
- `make DEVICE=XeGPU NUMWI=16 CONFIG=LDEBUG test`
- `make DEVICE=NvGPU NUMWI=128 CONFIG=LDEBUG test`